### PR TITLE
Proposal (to be discussed) for allowing function that USE context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ modules/
 spec/fixtures/
 .DS_Store
 Gemfile.lock
+.bundle/

--- a/lib/puppet_x/icinga2/utils.rb
+++ b/lib/puppet_x/icinga2/utils.rb
@@ -105,7 +105,12 @@ module Puppet
           if row =~ /^(.+)\s([\+-]|\*|\/|==|!=|&&|\|{2}|in)\s(.+)$/
             result += "%s %s %s" % [ parse($1), $2, parse($3) ]
           else
-            if row =~ /^(.+)\((.*)$/
+             # fct(a,b) use (c) {} (If this is a function, we don't want to further parse the individual parts
+            # since they're likely to be variables… not string arguments?) (Do we expect the user to know what they're doing?)
+            # We could maybe have % [ $1.split().map ], but not for $2 or $3, since that would defeat the purpose of this...
+            if row =~ /^(?:.+)\((.*)\)\s*use\s*\((.*)\)\s*{(.*)}$/
+              result += "function (%s) use (%s) { %s }" % [ $1.split(',').map {|x| parse(x.lstrip)}.join(', '), $2.strip, $3.strip ]
+            elsif row =~ /^(.+)\((.*)$/
               result += "%s(%s" % [ $1, $2.split(',').map {|x| parse(x.lstrip)}.join(', ') ]
             elsif row =~ /^(.*)\)$/
               result += "%s)" % [ $1.split(',').map {|x| parse(x.lstrip)}.join(', ') ]

--- a/spec/defines/object_spec.rb
+++ b/spec/defines/object_spec.rb
@@ -213,6 +213,13 @@ describe('icinga2::object', :type => :define) do
       it { is_expected.to contain_concat__fragment('icinga2::object::foo::bar')
         .with_content(/foo = \{{2} unparsed string \}{2}\n/) }
     end
+
+    context "#{os} with attrs => { foo => function (bar) use (var) { unparsed string } }" do
+      let(:params) { {:attrs => { 'foo' => 'function  (bar) use (var)  {unparsed string}' }, :object_type => 'foo', :target => '/bar/baz', :order => '10'} }
+
+      it { is_expected.to contain_concat__fragment('icinga2::object::foo::bar')
+        .with_content(/foo = function \("bar"\) use \(var\) \{{1} unparsed string \}{1}\n/) }
+    end
   end
 end
 


### PR DESCRIPTION
This is related to https://monitoring-portal.org/index.php?thread/38672-trouble-figuring-out-variables-macros-in-apply-rules-with-puppet/&postID=239378#post239378 but in no way meant to be a final PR, but rather something to base an actual solution on. 

This regex allows to have parameters of the form 

```ruby
param => 'function (var) use (context) { expression }' 
```

where only var will be further parsed by the expression parser in utils.rb.

**Side-question:** How does one run a single spec?

I've tried 

```bash
~$ bundle exec rake spec spec/defines/object_spec.rb
```

but that will still run ALL of the specs.