### PR TITLE
[OSMC Hackathon] Adding initial SLES support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'
+gem 'facterdb', :git => 'https://github.com/jfryman/facterdb', :ref => 'sles-12-support'
 gem 'rspec-puppet-facts', '>= 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,79 @@
+GIT
+  remote: https://github.com/jfryman/facterdb
+  revision: 3e314963146b0b831441556f7be3960ef4c930fe
+  ref: sles-12-support
+  specs:
+    facterdb (0.3.8)
+      facter
+      jgrep
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.2.5)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    hiera (3.2.2)
+    jgrep (1.4.1)
+      json
+    json (2.0.2)
+    json_pure (1.8.3)
+    mcollective-client (2.9.1)
+      json
+      stomp
+      systemu
+    metaclass (0.0.4)
+    mocha (1.2.1)
+      metaclass (~> 0.0.1)
+    puppet (4.8.1)
+      CFPropertyList (~> 2.2.6)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure (~> 1.8)
+    puppet-lint (2.0.2)
+    puppet-syntax (2.1.1)
+      rake
+    puppetlabs_spec_helper (1.2.2)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
+    rake (11.3.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-puppet (2.5.0)
+      rspec
+    rspec-puppet-facts (1.7.0)
+      facter
+      facterdb (>= 0.3.0)
+      json
+      mcollective-client
+      puppet
+    rspec-support (3.5.0)
+    stomp (1.4.3)
+    systemu (2.6.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  facter (>= 1.7.0)
+  facterdb!
+  puppet (>= 3.3)
+  puppet-lint (>= 0.3.2)
+  puppetlabs_spec_helper (>= 0.1.0)
+  rspec-puppet-facts (>= 1.6.0)
+
+BUNDLED WITH
+   1.12.5

--- a/metadata.json
+++ b/metadata.json
@@ -51,6 +51,13 @@
         "14.04",
         "16.04"
       ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11",
+        "12"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR represents a bit of help I provided during the OSMC Hackathon in order to add SLES 12 support.

* Added SLES 12 facts to `facterdb` https://github.com/camptocamp/facterdb/pull/32
* (Temporary) Re-located Gemfile upstream to git
* Updated `metadata.json` to include SLES 11/12 tests.