### PR TITLE
make service validation consistent with host validation

### DIFF
--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -183,10 +183,10 @@ define icinga2::object::service (
   if $vars { validate_hash ($vars) }
   validate_string($check_command)
   if $max_check_attempts { validate_integer ($max_check_attempts) }
-  if $check_period { validate_integer ($check_period) }
-  if $check_timeout { validate_integer ($check_timeout) }
-  if $check_interval { validate_integer ($check_interval) }
-  if $retry_interval { validate_integer ($retry_interval) }
+  if $check_period { validate_string ($check_period) }
+  if $check_timeout { validate_re($check_timeout, '^\d+\.?\d*[d|h|m|s]?$') }
+  if $check_interval { validate_re($check_interval, '^\d+\.?\d*[d|h|m|s]?$') }
+  if $retry_interval { validate_re($retry_interval, '^\d+\.?\d*[d|h|m|s]?$') }
   if $enable_notifications { validate_bool ($enable_notifications) }
   if $enable_active_checks { validate_bool ($enable_active_checks) }
   if $enable_passive_checks { validate_bool ($enable_passive_checks) }

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -165,14 +165,14 @@ describe('icinga2::object::service', :type => :define) do
     end
 
 
-    context "#{os} with check_interval => 30" do
-      let(:params) { {:check_interval => '30', :target => '/bar/baz',
+    context "#{os} with check_interval => 30s" do
+      let(:params) { {:check_interval => '30s', :target => '/bar/baz',
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::Service::bar')
                               .with({'target' => '/bar/baz'})
-                              .with_content(/check_interval = 30/) }
+                              .with_content(/check_interval = 30s/) }
     end
 
 


### PR DESCRIPTION
Currently service's parameters `check_timeout`, `check_interval` are allow to integers while the same parameters in `host` declarations requires units.

I'd happy to fix the tests, but currently not a single rspec passes.