### PR TITLE
Correction to give possibility to export service to puppetdb

### DIFF
--- a/manifests/object.pp
+++ b/manifests/object.pp
@@ -120,7 +120,7 @@ define icinga2::object(
   }
 
   if $ensure != 'absent' {
-    concat::fragment { "icinga2::object::${object_type}::${object_name}":
+    concat::fragment { $title:
       target   => $target,
       content  => $::osfamily ? {
         'windows' => regsubst(template('icinga2/object.conf.erb'), '\n', "\r\n", 'EMG'),

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -128,6 +128,7 @@
 #
 
 define icinga2::object::service (
+  $service_name           = $title,
   $ensure                 = present,
   $display_name           = undef,
   $host_name              = undef,
@@ -177,6 +178,7 @@ define icinga2::object::service (
   validate_absolute_path($target)
   validate_string($order)
 
+  if $service_name { validate_string($service_name) }
   if $display_name { validate_string ($display_name) }
   validate_string($host_name)
   if $groups { validate_array ($groups) }
@@ -209,7 +211,7 @@ define icinga2::object::service (
   $attrs = {
     'display_name' => $display_name ,
     'host_name' => $host_name ,
-    'name' => $name ,
+    'name' => $service_name ,
     'groups' => $groups ,
     'vars' => $vars ,
     'check_command' => $check_command ,
@@ -239,7 +241,7 @@ define icinga2::object::service (
   # create object
   icinga2::object { "icinga2::object::Service::${title}":
     ensure       => $ensure,
-    object_name  => $name,
+    object_name  => $service_name,
     object_type  => 'Service',
     import       => $import,
     apply        => $apply,


### PR DESCRIPTION
Hi,

maybe I doesn't understand this module, but I was not able to export a icinga::object::service resource to my puppetdb. In icinga2 you must create a service object on agent and on master right?

I have something like this in my own puppet manifest
````
....
  ::icinga2::object::service { $object_servicename:
    target => "/etc/icinga2/conf.d/${object_servicename}.conf",
    import => $templates,
    display_name => $display_name,
    host_name => $host_name,
    groups => $groups,
    vars => $vars,
    enable_flapping => $enable_flapping,
    check_command => $check_command,
  }
  if $export {
    @@::icinga2::object::service { "${::fqdn}_${object_servicename}":
      service_name => $object_servicename,
      import => $templates,
      display_name => $display_name,
      host_name => $host_name,
      groups => $groups,
      vars => $vars,
      enable_flapping => $enable_flapping,
      check_command => $check_command,
 # ....
      target => "/etc/icinga2/repository.d/hosts/${::fqdn}/${object_servicename}.conf",
      zone => $zone,
      command_endpoint => $zone,
    }
  }
````

On Icinga Master server
````
  Icinga2::Object::Host <<| |>>
  Icinga2::Object::Service <<| |>>
  Icinga2::Object::Zone <<| |>>
  Icinga2::Object::Endpoint <<| |>>
  File <<| tag == 'icinga_host_folder' |>>
````
After my first commit I had problem with concat::fragment resource key name, I changed a to title, because I think is more unique when you collect your Resources.

Maybe I do something totally wrong, then let me know how I must configure icinga2 with Puppet.

Best Regards
Reamer