### PR TITLE
Don't call private method preferred_run_mode= in facts

### DIFF
--- a/lib/facter/icinga2_puppet.rb
+++ b/lib/facter/icinga2_puppet.rb
@@ -1,6 +1,4 @@
-require 'facter'
-
-Puppet.settings.preferred_run_mode= :agent
+require 'puppet'
 
 Facter.add(:icinga2_puppet_hostcert) do
   setcode do


### PR DESCRIPTION
The method preferred_run_mode= is private and should not be called
externally, especially not in custom facts. Doing so breaks a Puppet
master in interesting ways and is entirely unnecessary.

Providing Puppet settings as facts works fine when simply requiring
'puppet' instead of 'facter'.