### PR TITLE
Fix non-breaking space.

### DIFF
--- a/manifests/feature/idopgsql.pp
+++ b/manifests/feature/idopgsql.pp
@@ -105,7 +105,7 @@ class icinga2::feature::idopgsql(
   validate_bool($enable_ha)
   validate_re($failover_timeout, '^\d+[ms]*$')
   if $cleanup { validate_hash($cleanup) }
-  if $categories { validate_array($categories) }
+  if $categories { validate_array($categories) }
   validate_bool($import_schema)
 
   $conf_dir  = $::icinga2::params::conf_dir


### PR DESCRIPTION
This character causes puppet run to fail with an "invalid byte sequence
in US-ASCII" error.