### PR TITLE
Add possibility to use ip or hostname.

### DIFF
--- a/manifests/feature/gelf.pp
+++ b/manifests/feature/gelf.pp
@@ -38,7 +38,7 @@ class icinga2::feature::gelf(
   # validation
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_ip_address($host)
+  validate_string($host)
   validate_integer($port)
   validate_string($source)
   validate_bool($enable_send_perfdata)

--- a/manifests/feature/graphite.pp
+++ b/manifests/feature/graphite.pp
@@ -46,7 +46,7 @@ class icinga2::feature::graphite(
   # validation
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_ip_address($host)
+  validate_string($host)
   validate_integer($port)
   validate_string($host_name_template)
   validate_string($service_name_template)

--- a/manifests/feature/idomysql.pp
+++ b/manifests/feature/idomysql.pp
@@ -158,7 +158,7 @@ class icinga2::feature::idomysql(
 
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_ip_address($host)
+  validate_string($host)
   validate_integer($port)
   if $socket_path { validate_absolute_path($socket_path) }
   validate_string($user)

--- a/manifests/feature/idopgsql.pp
+++ b/manifests/feature/idopgsql.pp
@@ -94,7 +94,7 @@ class icinga2::feature::idopgsql(
 
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_ip_address($host)
+  validate_string($host)
   validate_integer($port)
   validate_string($user)
   validate_string($password)

--- a/manifests/feature/influxdb.pp
+++ b/manifests/feature/influxdb.pp
@@ -128,7 +128,7 @@ class icinga2::feature::influxdb(
 
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_ip_address($host)
+  validate_string($host)
   validate_integer($port)
   validate_string($database)
   validate_string($username)

--- a/manifests/feature/livestatus.pp
+++ b/manifests/feature/livestatus.pp
@@ -47,7 +47,7 @@ class icinga2::feature::livestatus(
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
   validate_re($socket_type, [ '^unix$', '^tcp$' ],
     "${socket_type} isn't supported. Valid values are 'unix' and 'tcp'.")
-  validate_ip_address($bind_host)
+  validate_string($bind_host)
   validate_integer($bind_port)
   validate_absolute_path($socket_path)
   validate_absolute_path($compat_log_path)

--- a/manifests/feature/opentsdb.pp
+++ b/manifests/feature/opentsdb.pp
@@ -30,7 +30,7 @@ class icinga2::feature::opentsdb(
   # validation
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_ip_address($host)
+  validate_string($host)
   validate_integer($port)
 
   # compose attributes

--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -53,7 +53,7 @@ define icinga2::object::endpoint(
   validate_integer($order)
 
   if $endpoint { validate_string($endpoint) }
-  if $host { validate_ip_address($host) }
+  if $host { validate_string($host) }
   if $port { validate_integer($port) }
   if $log_duration { validate_re($log_duration, '^\d+\.?\d*[d|h|m|s]?$') }
 

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -158,8 +158,8 @@ define icinga2::object::host(
   validate_integer($order)
 
   if $hostname { validate_string($hostname) }
-  if $address { validate_ip_address($address) }
-  if $address6 { validate_ip_address($address6) }
+  if $address { validate_string($address) }
+  if $address6 { validate_string($address6) }
   if $vars { validate_hash($vars) }
   if $groups { validate_array($groups) }
   if $display_name { validate_string($display_name) }

--- a/spec/classes/gelf_spec.rb
+++ b/spec/classes/gelf_spec.rb
@@ -52,10 +52,12 @@ describe('icinga2::feature::gelf', :type => :class) do
     end
 
 
-    context "#{os} with host => foo (not a valid IP address)" do
-      let(:params) { {:host => 'foo'} }
+    context "#{os} with host => foo.example.com" do
+      let(:params) { {:host => 'foo.example.com'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::GelfWriter::gelf')
+        .with({ 'target' => '/etc/icinga2/features-available/gelf.conf' })
+        .with_content(/host = "foo.example.com"/) }
     end
 
 
@@ -183,10 +185,12 @@ describe('icinga2::feature::gelf', :type => :class) do
   end
 
 
-  context "Windows 2012 R2 with host => foo (not a valid IP address)" do
-    let(:params) { {:host => 'foo'} }
+  context "Windows 2012 R2 with host => foo.example.com" do
+    let(:params) { {:host => 'foo.example.com'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::GelfWriter::gelf')
+                            .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/gelf.conf' })
+                            .with_content(/host = "foo.example.com"/) }
   end
 
 

--- a/spec/classes/graphite_spec.rb
+++ b/spec/classes/graphite_spec.rb
@@ -55,10 +55,12 @@ describe('icinga2::feature::graphite', :type => :class) do
     end
 
 
-    context "#{os} with host => foo (not a valid IP address)" do
-      let(:params) { {:host => 'foo'} }
+    context "#{os} with host => foo.example.com" do
+      let(:params) { {:host => 'foo.example.com'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::GraphiteWriter::graphite')
+        .with({ 'target' => '/etc/icinga2/features-available/graphite.conf' })
+        .with_content(/host = "foo.example.com"/) }
     end
 
 
@@ -229,10 +231,12 @@ describe('icinga2::feature::graphite', :type => :class) do
   end
 
 
-  context "Windows 2012 R2 with host => foo (not a valid IP address)" do
-    let(:params) { {:host => 'foo'} }
+  context "Windows 2012 R2 with host => foo.example.com" do
+    let(:params) { {:host => 'foo.example.com'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::GraphiteWriter::graphite')
+                            .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/graphite.conf' })
+                            .with_content(/host = "foo.example.com"/) }
   end
 
 

--- a/spec/classes/idomysql_spec.rb
+++ b/spec/classes/idomysql_spec.rb
@@ -54,10 +54,12 @@ describe('icinga2::feature::idomysql', :type => :class) do
     end
 
 
-    context "#{os} with host => foo (not a valid IP address)" do
-      let(:params) { {:host => 'foo'} }
+    context "#{os} with host => foo.example.com" do
+      let(:params) { {:host => 'foo.example.com'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::IdoMysqlConnection::ido-mysql')
+                              .with({ 'target' => '/etc/icinga2/features-available/ido-mysql.conf' })
+                              .with_content(/host = "foo.example.com"/) }
     end
 
 
@@ -437,10 +439,12 @@ describe('icinga2::feature::idomysql', :type => :class) do
   end
 
 
-  context "Windows 2012 R2 with host => foo (not a valid IP address)" do
-    let(:params) { {:host => 'foo'} }
+  context "Windows 2012 R2 with host => foo.example.com" do
+    let(:params) { {:host => 'foo.example.com'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::IdoMysqlConnection::ido-mysql')
+                            .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/ido-mysql.conf' })
+                            .with_content(/host = "foo.example.com"/) }
   end
 
 

--- a/spec/classes/idopgsql_spec.rb
+++ b/spec/classes/idopgsql_spec.rb
@@ -49,10 +49,12 @@ describe('icinga2::feature::idopgsql', :type => :class) do
     end
 
 
-    context "#{os} with host => foo (not a valid IP address)" do
-      let(:params) { {:host => 'foo'} }
+    context "#{os} with host => foo.example.com" do
+      let(:params) { {:host => 'foo.example.com'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::IdoPgsqlConnection::ido-pgsql')
+                              .with({ 'target' => '/etc/icinga2/features-available/ido-pgsql.conf' })
+                              .with_content(/host = "foo.example.com"/) }
     end
 
 
@@ -286,10 +288,12 @@ describe('icinga2::feature::idopgsql', :type => :class) do
   end
 
 
-  context "Windows 2012 R2 with host => foo (not a valid IP address)" do
-    let(:params) { {:host => 'foo'} }
+  context "Windows 2012 R2 with host => foo.example.com" do
+    let(:params) { {:host => 'foo.example.com'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::IdoPgsqlConnection::ido-pgsql')
+                            .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/ido-pgsql.conf' })
+                            .with_content(/host = "foo.example.com"/) }
   end
 
 

--- a/spec/classes/influxdb_spec.rb
+++ b/spec/classes/influxdb_spec.rb
@@ -58,10 +58,12 @@ describe('icinga2::feature::influxdb', :type => :class) do
     end
 
 
-    context "#{os} with host => foo (not a valid IP address)" do
-      let(:params) { {:host => 'foo'} }
+    context "#{os} with host => foo.example.com" do
+      let(:params) { {:host => 'foo.example.com'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::InfluxdbWriter::influxdb')
+                              .with({ 'target' => '/etc/icinga2/features-available/influxdb.conf' })
+                              .with_content(/host = "foo.example.com"/) }
     end
 
 
@@ -438,10 +440,12 @@ describe('icinga2::feature::influxdb', :type => :class) do
   end
 
 
-  context "Windows 2012 R2 with host => foo (not a valid IP address)" do
-    let(:params) { {:host => 'foo'} }
+  context "Windows 2012 R2 with host => foo.example.com" do
+    let(:params) { {:host => 'foo.example.com'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::InfluxdbWriter::influxdb')
+                            .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/influxdb.conf' })
+                            .with_content(/host = "foo.example.com"/) }
   end
 
 

--- a/spec/classes/livestatus_spec.rb
+++ b/spec/classes/livestatus_spec.rb
@@ -70,10 +70,12 @@ describe('icinga2::feature::livestatus', :type => :class) do
     end
 
 
-    context "#{os} with bind_host => foo (not a valid IP address)" do
-      let(:params) { {:bind_host => 'foo'} }
+    context "#{os} with bind_host => foo.example.com" do
+      let(:params) { {:bind_host => 'foo.example.com'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::LivestatusListener::livestatus')
+        .with({ 'target' => '/etc/icinga2/features-available/livestatus.conf' })
+        .with_content(/bind_host = "foo.example.com"/) }
     end
 
 
@@ -208,10 +210,12 @@ describe('icinga2::feature::livestatus', :type => :class) do
   end
 
 
-  context "Windows 2012 R2 with bind_host => foo (not a valid IP address)" do
-    let(:params) { {:bind_host => 'foo'} }
+  context "Windows 2012 R2 with bind_host => foo.example.com" do
+    let(:params) { {:bind_host => 'foo.example.com'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::LivestatusListener::livestatus')
+                            .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/livestatus.conf' })
+                            .with_content(/bind_host = "foo.example.com"/) }
   end
 
 

--- a/spec/classes/opentsdb_spec.rb
+++ b/spec/classes/opentsdb_spec.rb
@@ -51,10 +51,12 @@ describe('icinga2::feature::opentsdb', :type => :class) do
     end
 
 
-    context "#{os} with host => foo (not a valid IP address)" do
-      let(:params) { {:host => 'foo'} }
+    context "#{os} with host => foo.example.com" do
+      let(:params) { {:host => 'foo.example.com'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::OpenTsdbWriter::opentsdb')
+        .with({ 'target' => '/etc/icinga2/features-available/opentsdb.conf' })
+        .with_content(/host = "foo.example.com"/) }
     end
 
 
@@ -139,10 +141,12 @@ describe('icinga2::feature::opentsdb', :type => :class) do
   end
 
 
-  context "Windows 2012 R2 with host => foo (not a valid IP address)" do
-    let(:params) { {:host => 'foo'} }
+  context "Windows 2012 R2 with host => foo.example.com" do
+    let(:params) { {:host => 'foo.example.com'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::OpenTsdbWriter::opentsdb')
+                            .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/opentsdb.conf' })
+                            .with_content(/host = "foo.example.com"/) }
   end
 
 

--- a/spec/defines/endpoint_spec.rb
+++ b/spec/defines/endpoint_spec.rb
@@ -61,10 +61,11 @@ describe('icinga2::object::endpoint', :type => :define) do
     end
 
 
-    context "#{os} with host => foo (not a valid IP address" do
-      let(:params) { {:host => 'foo', :target => '/bar/baz'} }
+    context "#{os} with host => foo.example.com" do
+      let(:params) { {:host => 'foo.example.com', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::Endpoint::bar')
+        .with_content(/host = "foo.example.com"/) }
     end
 
 
@@ -172,10 +173,11 @@ describe('icinga2::object::endpoint', :type => :define) do
   end
 
 
-  context "Windows 2012 R2  with host => foo (not a valid IP address" do
-    let(:params) { {:host => 'foo', :target => 'C:/bar/baz'} }
+  context "Windows 2012 R2  with host => foo.example.com" do
+    let(:params) { {:host => 'foo.example.com', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::Endpoint::bar')
+                            .with_content(/host = "foo.example.com"/) }
   end
 
 

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -79,10 +79,12 @@ describe('icinga2::object::host', :type => :define) do
     end
 
 
-    context "#{os} with address => foo (not a valid IP address)" do
-      let(:params) { {:address => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
+    context "#{os} with address => foo.example.com" do
+      let(:params) { {:address => 'foo.example.com', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::Host::bar')
+        .with({'target' => '/bar/baz'})
+        .with_content(/address = "foo.example.com"/) }
     end
 
 
@@ -95,10 +97,12 @@ describe('icinga2::object::host', :type => :define) do
     end
 
 
-    context "#{os} with address6 => foo (not a valid IP address)" do
-      let(:params) { {:address6 => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
+    context "#{os} with address6 => foo.example.com" do
+      let(:params) { {:address6 => 'foo.example.com', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::Host::bar')
+        .with({'target' => '/bar/baz'})
+        .with_content(/address6 = "foo.example.com"/) }
     end
 
 
@@ -630,10 +634,12 @@ describe('icinga2::object::host', :type => :define) do
   end
 
 
-  context "Windows 2012 R2 with address => foo (not a valid IP address)" do
-    let(:params) { {:address => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
+  context "Windows 2012 R2 with address => foo.example.com" do
+    let(:params) { {:address => 'foo.example.com', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::Host::bar')
+                            .with({'target' => '/bar/baz'})
+                            .with_content(/address = "foo.example.com"/) }
   end
 
 
@@ -646,10 +652,12 @@ describe('icinga2::object::host', :type => :define) do
   end
 
 
-  context "Windows 2012 R2 with address6 => foo (not a valid IP address)" do
-    let(:params) { {:address6 => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
+  context "Windows 2012 R2 with address6 => foo.example.com" do
+    let(:params) { {:address6 => 'foo.example.com', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a valid IP address/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::Host::bar')
+                            .with({'target' => '/bar/baz'})
+                            .with_content(/address6 = "foo.example.com"/) }
   end
 
 


### PR DESCRIPTION
In the icinga configs it is possible to use ips or hostnames. The module
only supported ips.

Change validate_ip_address($host) to validate_string($host) and adapt
spec tests.