### PR TITLE
Add possibility to set command parameter as String.

### DIFF
--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -67,7 +67,12 @@ define icinga2::object::checkcommand(
   validate_integer($order)
 
   if $checkcommand { validate_string($checkcommand) }
-  validate_array($command)
+  if ! is_array($command) {
+    validate_string($command)
+  }
+  if ! is_string($command) {
+    validate_array($command)
+  }
   if $env { validate_hash($env) }
   if $vars { validate_hash($vars) }
   if $timeout { validate_integer($timeout) }

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -69,7 +69,12 @@ define icinga2::object::eventcommand (
   validate_string($order)
   validate_array($import)
 
-  if $command { validate_array($command) }
+  if ! is_array($command) {
+    validate_string($command)
+  }
+  if ! is_string($command) {
+    validate_array($command)
+  }
   if $env { validate_hash($env) }
   if $vars { validate_hash($vars) }
   if $timeout { validate_integer($timeout) }

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -77,7 +77,12 @@ define icinga2::object::notificationcommand (
   validate_absolute_path($target)
   validate_string($order)
 
-  if $command { validate_array($command) }
+  if ! is_array($command) {
+    validate_string($command)
+  }
+  if ! is_string($command) {
+    validate_array($command)
+  }
   if $env { validate_hash ($env) }
   if $vars { validate_hash ($vars) }
   if $timeout { validate_integer ($timeout) }

--- a/spec/defines/checkcommand_spec.rb
+++ b/spec/defines/checkcommand_spec.rb
@@ -30,10 +30,12 @@ describe('icinga2::object::checkcommand', :type => :define) do
     end
 
 
-    context "#{os} with command => foo (not a valid array)" do
-      let(:params) { {:command => 'foo', :target => '/bar/baz'} }
+    context "#{os} with command => /usr/local/bin/foo" do
+      let(:params) { {:command => '/usr/local/bin/foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, / "foo" is not an Array/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::CheckCommand::bar')
+        .with({'target' => '/bar/baz'})
+        .with_content(/command = "\/usr\/local\/bin\/foo"/) }
     end
 
 
@@ -128,10 +130,12 @@ describe('icinga2::object::checkcommand', :type => :define) do
   end
 
 
-  context "Windows 2012 R2 with command => foo (not a valid array)" do
-    let(:params) { {:command => 'foo', :target => 'C:/bar/baz'} }
+  context "Windows 2012 R2 with command => /usr/local/bin/foo" do
+    let(:params) { {:command => '/usr/local/bin/foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, / "foo" is not an Array/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::CheckCommand::bar')
+      .with({'target' => 'C:/bar/baz'})
+      .with_content(/command = "\/usr\/local\/bin\/foo"/) }
   end
 
 

--- a/spec/defines/eventcommand_spec.rb
+++ b/spec/defines/eventcommand_spec.rb
@@ -50,13 +50,13 @@ describe('icinga2::object::eventcommand', :type => :define) do
                               .with_content(/command = \[ "foo", "bar", \]/) }
     end
 
+    context "#{os} with command => /usr/local/bin/foo" do
+      let(:params) { {:command => '/usr/local/bin/foo', :target => '/bar/baz'} }
 
-    context "#{os} with command => foo (not a valid array)" do
-      let(:params) { {:command => 'foo', :target => '/bar/baz'} }
-
-      it { is_expected.to raise_error(Puppet::Error, / "foo" is not an Array/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::EventCommand::bar')
+                              .with({'target' => '/bar/baz'})
+                              .with_content(/command = "\/usr\/local\/bin\/foo"/) }
     end
-
 
     context "#{os} with env => { foo => 'bar', bar => 'foo' }" do
       let(:params) { {:env => { 'foo' => "bar", 'bar' => "foo"}, :target => '/bar/baz', :command => ['foocommand'] } }
@@ -192,13 +192,13 @@ describe('icinga2::object::eventcommand', :type => :define) do
                             .with_content(/command = \[ "foo", "bar", \]/) }
   end
 
+  context "Windows 2012 R2 with command => /usr/local/bin/foo" do
+    let(:params) { {:command => '/usr/local/bin/foo', :target => 'C:/bar/baz'} }
 
-  context "Windows 2012 R2 with command => foo (not a valid array)" do
-    let(:params) { {:command => 'foo', :target => 'C:/bar/baz'} }
-
-    it { is_expected.to raise_error(Puppet::Error, / "foo" is not an Array/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::EventCommand::bar')
+                            .with({'target' => 'C:/bar/baz'})
+                            .with_content(/command = "\/usr\/local\/bin\/foo"/) } 
   end
-
 
   context "Windows 2012 R2 with env => { foo => 'bar', bar => 'foo' }" do
     let(:params) { {:env => { 'foo' => "bar", 'bar' => "foo"}, :target => 'C:/bar/baz', :command => ['foocommand'] } }

--- a/spec/defines/notificationcommand_spec.rb
+++ b/spec/defines/notificationcommand_spec.rb
@@ -50,13 +50,13 @@ describe('icinga2::object::notificationcommand', :type => :define) do
                               .with_content(/command = \[ "foo", "bar", \]/) }
     end
 
+    context "#{os} with command => /usr/local/bin/foo" do
+      let(:params) { {:command => '/usr/local/bin/foo', :target => '/bar/baz'} }
 
-    context "#{os} with command => foo (not a valid array)" do
-      let(:params) { {:command => 'foo', :target => '/bar/baz'} }
-
-      it { is_expected.to raise_error(Puppet::Error, / "foo" is not an Array/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::NotificationCommand::bar')
+                              .with({'target' => '/bar/baz'})
+                              .with_content(/command = "\/usr\/local\/bin\/foo"/) }
     end
-
 
     context "#{os} with env => { foo => 'bar', bar => 'foo' }" do
       let(:params) { {:env => { 'foo' => "bar", 'bar' => "foo"}, :target => '/bar/baz', :command => ['foocommand'] } }
@@ -191,13 +191,13 @@ describe('icinga2::object::notificationcommand', :type => :define) do
                             .with_content(/command = \[ "foo", "bar", \]/) }
   end
 
+  context "Windows 2012 R2 with command => /usr/local/bin/foo" do
+    let(:params) { {:command => '/usr/local/bin/foo', :target => 'C:/bar/baz'} }
 
-  context "Windows 2012 R2 with command => foo (not a valid array)" do
-    let(:params) { {:command => 'foo', :target => 'C:/bar/baz'} }
-
-    it { is_expected.to raise_error(Puppet::Error, / "foo" is not an Array/) }
+    it { is_expected.to contain_concat__fragment('icinga2::object::NotificationCommand::bar')
+                            .with({'target' => 'C:/bar/baz'})
+                            .with_content(/command = "\/usr\/local\/bin\/foo"/) } 
   end
-
 
   context "Windows 2012 R2 with env => { foo => 'bar', bar => 'foo' }" do
     let(:params) { {:env => { 'foo' => "bar", 'bar' => "foo"}, :target => 'C:/bar/baz', :command => ['foocommand'] } }


### PR DESCRIPTION
This fix establishes the desired behavior for the "command" parameter as
described in the icinga2 docs and in the icinga2 module parameter
description:

"The command. This can either be an array of individual command arguments.
Alternatively a string can be specified in which case the shell interpreter
(usually /bin/sh) takes care of parsing the command."

Update the rspec tests.