### PR TITLE
Don't set target default to undef

### DIFF
--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -91,8 +91,8 @@ define icinga2::object::dependency (
   $ignore                = [],
   $import                = [],
   $template              = false,
-  $target                = undef,
   $order                 = '70',
+  $target,
 ){
   include ::icinga2::params
 

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -100,8 +100,8 @@ define icinga2::object::notification (
   $ignore            = [],
   $import            = [],
   $template          = false,
-  $target            = undef,
   $order             = '85',
+  $target,
 ){
   include ::icinga2::params
 

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -62,7 +62,7 @@ define icinga2::object::notificationcommand (
   $template                 = false,
   $import                   = ['plugin-notification-command'],
   $order                    = '25',
-  $target                   = undef,
+  $target,
 ){
   include ::icinga2::params
 

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -70,7 +70,7 @@ define icinga2::object::scheduleddowntime (
   $assign                 = [],
   $ignore                 = [],
   $order                  = '90',
-  $target                 = undef,
+  $target,
 ){
   include ::icinga2::params
 

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -164,8 +164,8 @@ define icinga2::object::service (
   $ignore                 = [],
   $import                 = [],
   $template               = false,
-  $target                 = undef,
   $order                  = '60',
+  $target,
 ) {
 
   include ::icinga2::params

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -50,7 +50,7 @@ define icinga2::object::servicegroup (
   $template          = false,
   $import            = [],
   $order             = '65',
-  $target            = undef,
+  $target,
 ){
   include ::icinga2::params
 

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -53,8 +53,8 @@ define icinga2::object::timeperiod (
   $includes        = undef,
   $template        = false,
   $import          = ['legacy-timeperiod'],
-  $target          = undef,
   $order           = '35',
+  $target,
 ){
   include ::icinga2::params
 

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -73,7 +73,7 @@ define icinga2::object::user (
   $import               = [],
   $template             = false,
   $order                = '75',
-  $target               = undef,
+  $target,
 ){
   include ::icinga2::params
 

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -49,8 +49,8 @@ define icinga2::object::usergroup (
   $ignore         = [],
   $import         = [],
   $template       = false,
-  $target         = undef,
   $order          = '80',
+  $target,
 ){
   include ::icinga2::params
 


### PR DESCRIPTION
when target parameter needs to be set. The undef value would fail the
validate_absolute_path check anyway.