### PR TITLE
Temporarily add back $zone and $endpoint.

### DIFF
--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -7,6 +7,9 @@
 # [*ensure*]
 #   Set to present enables the object, absent disables it. Defaults to present.
 #
+# [*endpoint*]
+#   DEPRECATED. Do not use this parameter, use endpoint_name instead.
+#
 # [*endpoint_name*]
 #   Set the Icinga 2 name of the endpoint object. Defaults to title of the define resource.
 #
@@ -32,6 +35,7 @@
 #
 define icinga2::object::endpoint(
   $ensure        = present,
+  $enpoint       = $title,
   $endpoint_name = $title,
   $host          = undef,
   $port          = undef,
@@ -49,7 +53,13 @@ define icinga2::object::endpoint(
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
   validate_integer($order)
 
-  if $endpoint_name { validate_string($endpoint_name) }
+  if $endpoint_name {
+    $_endpoint_name = $endpoint_name
+  } else {
+    $_endpoint_name = $endpoint
+  }
+
+  if $_endpoint_name { validate_string($_endpoint_name) }
   if $host { validate_string($host) }
   if $port { validate_integer($port) }
   if $log_duration { validate_re($log_duration, '^\d+\.?\d*[d|h|m|s]?$') }
@@ -70,7 +80,7 @@ define icinga2::object::endpoint(
   # create object
   icinga2::object { "icinga2::object::Endpoint::${title}":
     ensure      => $ensure,
-    object_name => $endpoint_name,
+    object_name => $_endpoint_name,
     object_type => 'Endpoint',
     attrs       => $attrs,
     target      => $_target,

--- a/manifests/object/zone.pp
+++ b/manifests/object/zone.pp
@@ -7,6 +7,9 @@
 # [*ensure*]
 #   Set to present enables the object, absent disables it. Defaults to present.
 #
+# [*zone*]
+#   DEPRECATED. Do not use this parameter, use zone_name instead.
+#
 # [*zone_name*]
 #   Set the Icinga 2 name of the zone object. Defaults to title of the define resource.
 #
@@ -30,6 +33,7 @@
 #
 define icinga2::object::zone(
   $ensure    = present,
+  $zone      = $title,
   $zone_name = $title,
   $endpoints = undef,
   $parent    = undef,
@@ -45,7 +49,14 @@ define icinga2::object::zone(
   # validation
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($zone_name)
+
+  if $zone {
+    $_zone_name = $zone
+  } else {
+    $_zone_name = $zone_name
+  }
+
+  validate_string($_zone_name)
   validate_integer($order)
 
   if $endpoints { $_endpoints = any2array($endpoints) } else { $_endpoints = undef }
@@ -76,7 +87,7 @@ define icinga2::object::zone(
   # create object
   icinga2::object { "icinga2::object::Zone::${title}":
     ensure      => $ensure,
-    object_name => $zone_name,
+    object_name => $_zone_name,
     object_type => 'Zone',
     attrs       => $attrs,
     target      => $_target,


### PR DESCRIPTION
Re-add deprecated $zone and $endpoint parameters to allow for a transition period, especially for users using virtual or exported resources.
In fact, with exported resources in storeconfigs that use the old parameters, all puppet runs will fail when upgrading the module to a version
that only has the new parameters. Having a transition period will allow puppet to run and export new resources to storeconfig that use the new parameter names.