### PR TITLE
Allow other time units in notification and scheduleddowntime

### DIFF
--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -123,7 +123,7 @@ define icinga2::object::notification (
   if !is_string($user_groups) { validate_array($user_groups) }
   if $times { validate_hash ($times )}
   if $command { validate_string ($command )}
-  if $interval { validate_integer ($interval )}
+  if $interval { validate_re($interval, '^\d+(\.\d+)?[dhms]?$')}
   if $period { validate_string ($period )}
   if $zone { validate_string ($zone) }
   if !is_array($types) { validate_string($types) }

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -88,7 +88,7 @@ define icinga2::object::scheduleddowntime (
   if $author { validate_string($author) }
   if $comment { validate_string($comment) }
   if $fixed { validate_bool($fixed) }
-  if $duration { validate_integer($duration) }
+  if $duration { validate_re($duration, '^\d+(\.\d+)?[dhms]?$') }
   if $ranges { validate_hash($ranges) }
 
   # compose attributes

--- a/spec/defines/notification_spec.rb
+++ b/spec/defines/notification_spec.rb
@@ -132,11 +132,21 @@ describe('icinga2::object::notification', :type => :define) do
     end
 
 
-    context "#{os} with interval => foo (not a valid integer)" do
-      let(:params) { {:interval => 'foo', :target => '/bar/baz'} }
+    context "#{os} with interval => 30m" do
+      let(:params) { {:interval => '30m', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::Notification::bar')
+                              .with({'target' => '/bar/baz'})
+                              .with_content(/interval = 30m/) }
     end
+
+
+#    See: https://github.com/Icinga/puppet-icinga2/pull/220#issuecomment-275847137
+#    context "#{os} with interval => foo (not a valid integer)" do
+#      let(:params) { {:interval => 'foo', :target => '/bar/baz'} }
+#
+#      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+#    end
 
 
     context "#{os} with period => foo" do

--- a/spec/defines/scheduleddowntime_spec.rb
+++ b/spec/defines/scheduleddowntime_spec.rb
@@ -113,15 +113,28 @@ describe('icinga2::object::scheduleddowntime', :type => :define) do
     end
 
 
-    context "#{os} with duration => foo (not a valid integer)" do
-      let(:params) { {:duration => 'foo', :target => '/bar/baz',
+    context "#{os} with duration => 30m" do
+      let(:params) { {:duration => '30m', :target => '/bar/baz',
                       :host_name => 'foohost',
                       :author => 'fooauthor',
                       :comment => 'foocomment',
                       :ranges => { 'foo' => "bar", 'bar' => "foo"}} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to contain_concat__fragment('icinga2::object::ScheduledDowntime::bar')
+                              .with({'target' => '/bar/baz'})
+                              .with_content(/duration = 30m/) }
     end
+
+#    See: https://github.com/Icinga/puppet-icinga2/pull/220#issuecomment-275847137
+#    context "#{os} with duration => foo (not a valid integer)" do
+#      let(:params) { {:duration => 'foo', :target => '/bar/baz',
+#                      :host_name => 'foohost',
+#                      :author => 'fooauthor',
+#                      :comment => 'foocomment',
+#                      :ranges => { 'foo' => "bar", 'bar' => "foo"}} }
+#
+#      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+#    end
 
 
     context "#{os} with ranges => { foo => 'bar', bar => 'foo' }" do


### PR DESCRIPTION
Hi,

while i'm moving from the old puppet to the new, I have notice that values like 30m are not allowed anymore in some parameters.

Here is a PR for 2 cases, maybe there are a lot of more...