### PR TITLE
Remove Puppet 4 Warning - delete :undef symbols in attr hash

### DIFF
--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -315,7 +315,7 @@ class icinga2::feature::api(
   icinga2::object { 'icinga2::object::ApiListener::api':
     object_name => 'api',
     object_type => 'ApiListener',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/api.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/command.pp
+++ b/manifests/feature/command.pp
@@ -32,7 +32,7 @@ class icinga2::feature::command(
   icinga2::object { 'icinga2::object::ExternalCommandListener::command':
     object_name => 'command',
     object_type => 'ExternalCommandListener',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/command.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/compatlog.pp
+++ b/manifests/feature/compatlog.pp
@@ -40,7 +40,7 @@ class icinga2::feature::compatlog(
   icinga2::object { 'icinga2::object::CompatLogger::compatlog':
     object_name => 'compatlog',
     object_type => 'CompatLogger',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/compatlog.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/debuglog.pp
+++ b/manifests/feature/debuglog.pp
@@ -35,7 +35,7 @@ class icinga2::feature::debuglog(
   icinga2::object { 'icinga2::object::FileLogger::debuglog':
     object_name => 'debug-file',
     object_type => 'FileLogger',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/debuglog.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/gelf.pp
+++ b/manifests/feature/gelf.pp
@@ -50,7 +50,7 @@ class icinga2::feature::gelf(
   icinga2::object { 'icinga2::object::GelfWriter::gelf':
     object_name => 'gelf',
     object_type => 'GelfWriter',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/gelf.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/graphite.pp
+++ b/manifests/feature/graphite.pp
@@ -62,7 +62,7 @@ class icinga2::feature::graphite(
   icinga2::object { 'icinga2::object::GraphiteWriter::graphite':
     object_name => 'graphite',
     object_type => 'GraphiteWriter',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/graphite.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/idomysql.pp
+++ b/manifests/feature/idomysql.pp
@@ -319,7 +319,7 @@ class icinga2::feature::idomysql(
   icinga2::object { 'icinga2::object::IdoMysqlConnection::ido-mysql':
     object_name => 'ido-mysql',
     object_type => 'IdoMysqlConnection',
-    attrs       => merge($attrs, $attrs_ssl),
+    attrs       => delete_undef_values(merge($attrs, $attrs_ssl)),
     target      => "${conf_dir}/features-available/ido-mysql.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/idopgsql.pp
+++ b/manifests/feature/idopgsql.pp
@@ -141,7 +141,7 @@ class icinga2::feature::idopgsql(
   icinga2::object { 'icinga2::object::IdoPgsqlConnection::ido-pgsql':
     object_name => 'ido-pgsql',
     object_type => 'IdoPgsqlConnection',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/ido-pgsql.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/influxdb.pp
+++ b/manifests/feature/influxdb.pp
@@ -270,7 +270,7 @@ class icinga2::feature::influxdb(
   icinga2::object { 'icinga2::object::InfluxdbWriter::influxdb':
     object_name => 'influxdb',
     object_type => 'InfluxdbWriter',
-    attrs       => merge($attrs, $attrs_ssl),
+    attrs       => delete_undef_values(merge($attrs, $attrs_ssl)),
     target      => "${conf_dir}/features-available/influxdb.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/livestatus.pp
+++ b/manifests/feature/livestatus.pp
@@ -64,7 +64,7 @@ class icinga2::feature::livestatus(
   icinga2::object { 'icinga2::object::LivestatusListener::livestatus':
     object_name => 'livestatus',
     object_type => 'LivestatusListener',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/livestatus.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/mainlog.pp
+++ b/manifests/feature/mainlog.pp
@@ -39,7 +39,7 @@ class icinga2::feature::mainlog(
   icinga2::object { 'icinga2::object::FileLogger::mainlog':
     object_name => 'main-log',
     object_type => 'FileLogger',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/mainlog.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/opentsdb.pp
+++ b/manifests/feature/opentsdb.pp
@@ -38,7 +38,7 @@ class icinga2::feature::opentsdb(
   icinga2::object { 'icinga2::object::OpenTsdbWriter::opentsdb':
     object_name => 'opentsdb',
     object_type => 'OpenTsdbWriter',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/opentsdb.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/perfdata.pp
+++ b/manifests/feature/perfdata.pp
@@ -81,7 +81,7 @@ class icinga2::feature::perfdata(
   icinga2::object { 'icinga2::object::PerfdataWriter::perfdata':
     object_name => 'perfdata',
     object_type => 'PerfdataWriter',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/perfdata.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/statusdata.pp
+++ b/manifests/feature/statusdata.pp
@@ -49,7 +49,7 @@ class icinga2::feature::statusdata(
   icinga2::object { 'icinga2::object::StatusDataWriter::statusdata':
     object_name => 'statusdata',
     object_type => 'StatusDataWriter',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/statusdata.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/feature/syslog.pp
+++ b/manifests/feature/syslog.pp
@@ -33,7 +33,7 @@ class icinga2::feature::syslog(
   icinga2::object { 'icinga2::object::SyslogLogger::syslog':
     object_name => 'syslog',
     object_type => 'SyslogLogger',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => "${conf_dir}/features-available/syslog.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/manifests/object/apiuser.pp
+++ b/manifests/object/apiuser.pp
@@ -80,7 +80,7 @@ define icinga2::object::apiuser(
     ensure      => $ensure,
     object_name => $apiuser_name,
     object_type => 'ApiUser',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -87,7 +87,7 @@ define icinga2::object::checkcommand(
     object_type => 'CheckCommand',
     template    => $template,
     import      => $import,
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/checkresultreader.pp
+++ b/manifests/object/checkresultreader.pp
@@ -51,7 +51,7 @@ define icinga2::object::checkresultreader (
     ensure      => $ensure,
     object_name => $checkresultreader_name,
     object_type => 'CheckResultReader',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/compatlogger.pp
+++ b/manifests/object/compatlogger.pp
@@ -57,7 +57,7 @@ define icinga2::object::compatlogger (
     ensure      => $ensure,
     object_name => $compatlogger_name,
     object_type => 'CompatLogger',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -137,7 +137,7 @@ define icinga2::object::dependency (
     object_type  => 'Dependency',
     import       => $import,
     template     => $template,
-    attrs        => $attrs,
+    attrs        => delete_undef_values($attrs),
     apply        => $apply,
     apply_target => $apply_target,
     assign       => $assign,

--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -72,7 +72,7 @@ define icinga2::object::endpoint(
     ensure      => $ensure,
     object_name => $endpoint_name,
     object_type => 'Endpoint',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $_target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -88,7 +88,7 @@ define icinga2::object::eventcommand (
     object_name => $eventcommand_name,
     object_type => 'EventCommand',
     import      => $import,
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -221,7 +221,7 @@ define icinga2::object::host(
     object_type => 'Host',
     template    => $template,
     import      => $import,
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/hostgroup.pp
+++ b/manifests/object/hostgroup.pp
@@ -71,7 +71,7 @@ define icinga2::object::hostgroup(
     ensure      => $ensure,
     object_name => $hostgroup_name,
     object_type => 'HostGroup',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     assign      => $assign,
     ignore      => $ignore,
     target      => $target,

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -160,7 +160,7 @@ define icinga2::object::notification (
     object_type  => 'Notification',
     import       => $import,
     template     => $template,
-    attrs        => $attrs,
+    attrs        => delete_undef_values($attrs),
     target       => $target,
     order        => $order,
     apply        => $apply,

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -96,7 +96,7 @@ define icinga2::object::notificationcommand (
     object_type => 'NotificationCommand',
     template    => $template,
     import      => $import,
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -107,7 +107,7 @@ define icinga2::object::scheduleddowntime (
     ensure       => $ensure,
     object_name  => $scheduleddowntime_name,
     object_type  => 'ScheduledDowntime',
-    attrs        => $attrs,
+    attrs        => delete_undef_values($attrs),
     apply        => $apply,
     apply_target => $apply_target,
     assign       => $assign,

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -274,7 +274,7 @@ define icinga2::object::service (
     assign       => $assign,
     ignore       => $ignore,
     template     => $template,
-    attrs        => $attrs,
+    attrs        => delete_undef_values($attrs),
     target       => $target,
     order        => $order,
     notify       => Class['::icinga2::service'],

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -78,7 +78,7 @@ define icinga2::object::servicegroup (
     object_type => 'ServiceGroup',
     import      => $import,
     template    => $template,
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     assign      => $assign,
     ignore      => $ignore,
     target      => $target,

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -88,7 +88,7 @@ define icinga2::object::timeperiod (
     object_type => 'TimePeriod',
     template    => $template,
     import      => $import,
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -116,7 +116,7 @@ define icinga2::object::user (
     object_type => 'User',
     template    => $template,
     import      => $import,
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $target,
     order       => $order,
     notify      => Class['::icinga2::service'],

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -81,7 +81,7 @@ define icinga2::object::usergroup (
     object_type => 'UserGroup',
     import      => $import,
     template    => $template,
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     assign      => $assign,
     ignore      => $ignore,
     target      => $target,

--- a/manifests/object/zone.pp
+++ b/manifests/object/zone.pp
@@ -78,7 +78,7 @@ define icinga2::object::zone(
     ensure      => $ensure,
     object_name => $zone_name,
     object_type => 'Zone',
-    attrs       => $attrs,
+    attrs       => delete_undef_values($attrs),
     target      => $_target,
     order       => $order,
     notify      => Class['::icinga2::service'],


### PR DESCRIPTION
:undef is a symbol and can't not converted correctly to json
https://github.com/puppetlabs/puppet/blob/89205d63a831deb732276d9b1bc412d45e7a6567/lib/puppet/resource.rb#L119

Without this fix we get this warning on every catalogue compilation
https://github.com/puppetlabs/puppet/blob/89205d63a831deb732276d9b1bc412d45e7a6567/lib/puppet/resource.rb#L91

Example warning:
```
2017-01-30 16:47:14,133 WARN  [qtp909448294-67] [puppetserver] Puppet Resource 'Icinga2::Object[icinga2::object::ApiListener::api]' contains a Hash value. It will be converted to the String '{"cert_path"=>"/etc/icinga2/pki/webserver.xxxxxxx.de.crt", "key_path"=>"/etc/icinga2/pki/webserver.xxxxxx.de.key", "ca_path"=>"/etc/icinga2/pki/ca.crt", "accept_commands"=>true, "accept_config"=>true, "ticket_salt"=>"TicketSalt", "tls_protocolmin"=>:undef, "cipher_list"=>:undef}'
```
