### PR TITLE
Add apply_prefix argument to service object to fix issue #227

### DIFF
--- a/manifests/object.pp
+++ b/manifests/object.pp
@@ -21,6 +21,9 @@
 # [*apply_target*]
 #   An object type on which to target the apply rule. Valid values are `Host` and `Service`. Defaults to `Host`.
 #
+# [*apply_prefix*]
+#   An optional name prefix to use when using a loop apply statement.
+#
 # [*import*]
 #   A sorted list of templates to import in this object. Defaults to an empty array.
 #
@@ -54,6 +57,7 @@ define icinga2::object(
   $template     = false,
   $apply        = false,
   $apply_target = undef,
+  $apply_prefix = undef,
   $import       = [],
   $assign       = [],
   $ignore       = [],
@@ -91,6 +95,7 @@ define icinga2::object(
   unless is_bool($apply) { validate_re($apply, '^.+\s+(=>\s+.+\s+)?in\s+.+$') }
   if $apply_target { validate_re($apply_target, ['^Host$', '^Service$'],
     "${apply_target} isn't supported. Valid values are 'Host' and 'Service'.") }
+  if $apply_prefix { validate_string($apply_prefix) }
   validate_array($import)
   validate_array($assign)
   validate_array($ignore)

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -109,6 +109,9 @@
 #   Dispose an apply instead an object if set to 'true'. Value is taken as statement,
 #   i.e. 'vhost => config in host.vars.vhosts'. Defaults to false.
 #
+# [*apply_prefix*]
+#   An optional name prefix to use when using a loop apply statement.
+#
 # [*assign*]
 #   Assign user group members using the group assign rules.
 #
@@ -185,6 +188,7 @@ define icinga2::object::service (
   $icon_image             = undef,
   $icon_image_alt         = undef,
   $apply                  = false,
+  $apply_prefix           = undef,
   $assign                 = [],
   $ignore                 = [],
   $import                 = [],
@@ -231,6 +235,7 @@ define icinga2::object::service (
   if $action_url { validate_string ($action_url) }
   if $icon_image { validate_absolute_path ($icon_image) }
   if $icon_image_alt { validate_string ($icon_image_alt) }
+  if $apply_prefix { validate_string($apply_prefix) }
 
 
   # compose the attributes
@@ -271,6 +276,7 @@ define icinga2::object::service (
     import       => $import,
     apply        => $apply,
     apply_target => 'Host',
+    apply_prefix => $apply_prefix,
     assign       => $assign,
     ignore       => $ignore,
     template     => $template,

--- a/templates/object.conf.erb
+++ b/templates/object.conf.erb
@@ -1,5 +1,5 @@
 
-<% if @apply.is_a?(String) %>apply <%= @object_type -%> for (<%= @apply %>) to <%= @apply_target -%> {
+<% if @apply.is_a?(String) %>apply <%= @object_type -%> <% if @apply_prefix %>"<%= @apply_prefix %>" <% end %>for (<%= @apply %>) to <%= @apply_target -%> {
 <% else -%>
 <% if @apply %>apply<% else -%>
 <% if @template %>template<% else %>object<% end -%>


### PR DESCRIPTION
Hi, 

Although I personally would prefer that the default should be to add the prefix to all apply loops I understand that some may think otherwise. Also, that would be a breaking change.

With this commit I simply add an apply_prefix argument that allows you to optionally add a service prefix to be able to add services that otherwise would result in name collisions. By default apply_prefix is set to undef to preserve the current module behavior. 