### PR TITLE
enable setting of bind_host and bind_port for feature::api

### DIFF
--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -82,6 +82,12 @@
 # [*ssl_cipher_list*]
 #   List of allowed TLS ciphers, to finetune encryption. Default undef (e.g. "HIGH:MEDIUM:!aNULL:!MD5:!RC4")
 #
+# [*bind_host*]
+#   The IP address the api listener will be bound to. (e.g. 0.0.0.0)
+#
+# [*bind_port*]
+#   The port the api listener will be bound to. (e.g. 5665)
+#
 # === Variables
 #
 # [*node_name*]
@@ -152,6 +158,8 @@ class icinga2::feature::api(
   $ssl_cacert      = undef,
   $ssl_protocolmin = undef,
   $ssl_cipher_list = undef,
+  $bind_host       = undef,
+  $bind_port       = undef,
 ) {
 
   $conf_dir  = $::icinga2::params::conf_dir
@@ -210,6 +218,14 @@ class icinga2::feature::api(
   if $ssl_cipher_list {
     validate_string($ssl_cipher_list)
   }
+  if $bind_host {
+    validate_string($bind_host)
+  }
+  if $bind_port {
+    validate_integer($bind_port)
+  }
+
+
 
   # handle the certificate's stuff
   case $pki {
@@ -326,6 +342,8 @@ class icinga2::feature::api(
     ticket_salt     => $ticket_salt,
     tls_protocolmin => $ssl_protocolmin,
     cipher_list     => $ssl_cipher_list,
+    bind_host       => $bind_host,
+    bind_port       => $bind_port,
   }
 
   # create endpoints and zones

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -46,7 +46,9 @@ describe('icinga2::feature::api', :type => :class) do
         .with({ 'target' => '/etc/icinga2/features-available/api.conf' })
         .with_content(/accept_config = false/)
         .with_content(/accept_commands = false/)
-        .with_content(/ticket_salt = TicketSalt/) }
+        .with_content(/ticket_salt = TicketSalt/)
+        .without_content(/bind_\w+ =/)
+      }
 
       it { is_expected.to contain_file('/etc/icinga2/pki/host.example.org.key')  }
       it { is_expected.to contain_file('/etc/icinga2/pki/host.example.org.crt')  }
@@ -279,6 +281,17 @@ describe('icinga2::feature::api', :type => :class) do
           .with({ 'target' => '/etc/icinga2/features-available/api.conf' })
           .with_content(/tls_protocolmin = "TLSv1.2"/)
           .with_content(/cipher_list = "HIGH:MEDIUM:!aNULL:!MD5:!RC4"/)
+      end
+    end
+
+    context "#{os} with bind settings" do
+      let(:params) { { bind_host: '::', bind_port: 1234 } }
+
+      it 'should set bind_* settings' do
+        is_expected.to contain_concat__fragment('icinga2::object::ApiListener::api')
+          .with({ 'target' => '/etc/icinga2/features-available/api.conf' })
+          .with_content(/bind_host = "::"/)
+          .with_content(/bind_port = 1234/)
       end
     end
   end
@@ -555,5 +568,16 @@ describe('icinga2::feature::api', :type => :class) do
     let(:params) { {:zones => 'foo'} }
 
     it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+  end
+
+  context 'Windows 2012 R2 with bind settings' do
+    let(:params) { { bind_host: '::', bind_port: 1234 } }
+
+    it 'should set bind_* settings' do
+      is_expected.to contain_concat__fragment('icinga2::object::ApiListener::api')
+        .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/api.conf' })
+        .with_content(/bind_host = "::"/)
+        .with_content(/bind_port = 1234/)
+    end
   end
 end


### PR DESCRIPTION
usecase: I need to set bind_host to '::' for ipv6 listening.