### PR TITLE
Allow alternate restart command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,10 @@
 #   If set to true the service is managed otherwise the service also
 #   isn't restarted if a config file changed. Defaults to true.
 #
+# [*service_restart*]
+#   If set this command will be used to restart the service, rather than stopping and starting it.
+#   Defaults to undef.
+#
 # [*features*]
 #   List of features to activate. Defaults to [checker, mainlog, notification].
 #
@@ -122,15 +126,16 @@
 #
 #
 class icinga2(
-  $ensure         = running,
-  $enable         = true,
-  $manage_repo    = false,
-  $manage_service = true,
-  $features       = $icinga2::params::default_features,
-  $purge_features = true,
-  $constants      = {},
-  $plugins        = $icinga2::params::plugins,
-  $confd          = true,
+  $ensure          = running,
+  $enable          = true,
+  $manage_repo     = false,
+  $manage_service  = true,
+  $service_restart = undef,
+  $features        = $icinga2::params::default_features,
+  $purge_features  = true,
+  $constants       = {},
+  $plugins         = $icinga2::params::plugins,
+  $confd           = true,
 ) inherits ::icinga2::params {
 
   validate_re($ensure, [ '^running$', '^stopped$' ],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -20,15 +20,20 @@ class icinga2::service {
     fail("icinga2::service is a private class of the module icinga2, you're not permitted to use it.")
   }
 
-  $ensure         = $::icinga2::ensure
-  $enable         = $::icinga2::enable
-  $manage_service = $::icinga2::manage_service
-  $service        = $::icinga2::params::service
+  $ensure          = $::icinga2::ensure
+  $enable          = $::icinga2::enable
+  $manage_service  = $::icinga2::manage_service
+  $service         = $::icinga2::params::service
+  $service_restart = $::icinga2::service_restart
+
+  $service_hasrestart = $service_restart == undef
 
   if $manage_service {
     service { $service:
-      ensure => $ensure,
-      enable => $enable,
+      ensure     => $ensure,
+      enable     => $enable,
+      restart    => $service_restart,
+      hasrestart => $service_hasrestart,
     }
   }
 


### PR DESCRIPTION
This is inspired by the puppetlabs-apache module. It allows for an alternate restart command to be used to restart the service, rather than completely stopping and starting it.

I'm using this to call reload on the service instead of restart. If the configuration is broken this fails the Puppet run (because reload checks the config before proceeding) rather than stopping and then failing to start Icinga, which is not desirable. This might not suit everyone thus making it optional.

If no additional parameter is given when calling the icinga2 class this change is a noop, so it won't affect any existing installations.