### PR TITLE
Feature checker concurrent checks

### DIFF
--- a/manifests/feature/checker.pp
+++ b/manifests/feature/checker.pp
@@ -10,20 +10,38 @@
 #
 class icinga2::feature::checker(
   $ensure = present,
+  $concurrent_checks = undef,
 ) {
 
   $conf_dir = $::icinga2::params::conf_dir
+  $_default_attrs = {}
 
   # validation
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
 
+  if $concurrent_checks {
+     validate_integer($concurrent_checks)
+     if $concurrent_checks < 0 {
+       fail('$concurrent_checks needs to be an integer, either zero or positiv.')
+     }
+     $_concurrent_checks = $concurrent_checks
+  }
+
+  if $_concurrent_checks {
+    $_attrs = {
+      concurrent_checks => $_concurrent_checks,
+    }
+  } else {
+    $_attrs = $_default_attrs
+  }
+
   # create object
   icinga2::object { 'icinga2::object::CheckerComponent::checker':
     object_name => 'checker',
     object_type => 'CheckerComponent',
-    attrs       => {},
-    attrs_list  => [],
+    attrs       => delete_undef_values($_attrs),
+    #attrs_list  => keys($_attrs),
     target      => "${conf_dir}/features-available/checker.conf",
     order       => '10',
     notify      => $ensure ? {

--- a/spec/classes/checker_spec.rb
+++ b/spec/classes/checker_spec.rb
@@ -29,6 +29,12 @@ describe('icinga2::feature::checker', :type => :class) do
       it { is_expected.to contain_icinga2__object('icinga2::object::CheckerComponent::checker')
         .with({ 'target' => '/etc/icinga2/features-available/checker.conf' }) }
     end
+
+    context "#{os} with concurrent_checks => foo (not a valid integer)" do
+      let(:params) { {:concurrent_checks => 'foo'} }
+
+      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    end
   end
 end
 


### PR DESCRIPTION
Hello,

I've had the need, to limit the concurrent checks the Checker performs at the same time.

I just have an issue at the line 44 in ```checker.pp```. If I add the _attr_list_ parameter (that I've found also being present in other features)...

```
 attrs_list  => keys($_attrs),
```

... I get the error...

```
Icinga2::Object[icinga2::object::CheckerComponent::checker]: has no parameter named 'attrs_list' at checker.pp:40
```

But I've found no place where to tell that CheckerComponent actually has a ```attrs_list``` parameter.