### PR TITLE
Update icingamaster.yaml because yaml-lint failes

### DIFF
--- a/examples/example3/hieradata/nodes/icingamaster.yaml
+++ b/examples/example3/hieradata/nodes/icingamaster.yaml
@@ -27,5 +27,5 @@ icinga2::feature::graphite::enable_send_metadata: true
 
 icinga2::feature::idomysql::database: icinga2
 icinga2::feature::idomysql::user: icinga2
-icinga2::feature::idomysql::password: *************
+icinga2::feature::idomysql::password: "*************"
 icinga2::feature::idomysql::import_schema: true


### PR DESCRIPTION
icinga2/examples/example3/hieradata/nodes/icingamaster.yaml): 
did not find expected alphabetic or numeric character while scanning an alias at line 30 column 39