### PR TITLE
fix time periods example

### DIFF
--- a/examples/example_config.pp
+++ b/examples/example_config.pp
@@ -315,13 +315,13 @@ file { '/etc/icinga2/example.d':
   import       => [ 'legacy-timeperiod' ],
   display_name => 'Icinga 2 9to5 TimePeriod',
   ranges       => {
-    monday    => '00:09-17:00',
-    tuesday   => '00:09-17:00',
-    wednesday => '00:09-17:00',
-    thursday  => '00:09-17:00',
-    friday    => '00:09-17:00',
-    saturday  => '00:09-17:00',
-    sunday    => '00:09-17:00',
+    monday    => '09:00-17:00',
+    tuesday   => '09:00-17:00',
+    wednesday => '09:00-17:00',
+    thursday  => '09:00-17:00',
+    friday    => '09:00-17:00',
+    saturday  => '09:00-17:00',
+    sunday    => '09:00-17:00',
   },
 }
 


### PR DESCRIPTION
9 to 5 usually doesn't mean 9 minutes after midnight till 5 in the afternoon :)