### PR TITLE
Align Ownership Rights for straight umasks

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,11 +34,15 @@ class icinga2::config {
   file { "${conf_dir}/constants.conf":
     ensure  => file,
     content => $template_constants,
+    owner   => $::icinga2::params::user,
+    group   => $::icinga2::params::group,
   }
 
   file { "${conf_dir}/icinga2.conf":
     ensure  => file,
     content => $template_mainconfig,
+    owner   => $::icinga2::params::user,
+    group   => $::icinga2::params::group,
   }
 
   file { "${conf_dir}/features-enabled":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -37,7 +37,8 @@ class icinga2::install {
 
   # anchor, i.e. for config directory set by confd parameter
   file { $conf_dir:
-    ensure  => directory,
+    ensure => directory,
+    mode   => '0755',
   }
   file { $pki_dir:
     ensure  => directory,


### PR DESCRIPTION
On systems with tougher umasks like 0027 the module till now causes the icinga user not beeing able to read the conf directory /etc/icinga2 and the files icinga2.conf and constants.conf.

Please take this upstream, it might help others with tight umasks, and not causing any problems on "normal" installations.