### PR TITLE
Remove deprecated apt options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This module depends on:
 
 Depending on your setup following modules may also be required:
 
-* [puppetlabs/apt] >= 1.8.0
+* [puppetlabs/apt] >= 2.0.0
 * [puppetlabs/chocolatey] >= 0.7.0
 * [darin/zypprepo] >= 1.0.2
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -44,23 +44,25 @@ class icinga2::repo {
           'debian': {
             include ::apt, ::apt::backports
             apt::source { 'icinga-stable-release':
-              location    => 'http://packages.icinga.com/debian',
-              release     => "icinga-${::lsbdistcodename}",
-              repos       => 'main',
-              key_source  => 'http://packages.icinga.com/icinga.key',
-              key         => 'F51A91A5EE001AA5D77D53C4C6E319C334410682',
-              include_src => false,
+              location => 'http://packages.icinga.com/debian',
+              release  => "icinga-${::lsbdistcodename}",
+              repos    => 'main',
+              key      => {
+                id     => 'F51A91A5EE001AA5D77D53C4C6E319C334410682',
+                source => 'http://packages.icinga.com/icinga.key',
+              };
             }
           }
           'ubuntu': {
             include ::apt
             apt::source { 'icinga-stable-release':
-              location    => 'http://packages.icinga.com/ubuntu',
-              release     => "icinga-${::lsbdistcodename}",
-              repos       => 'main',
-              key_source  => 'http://packages.icinga.com/icinga.key',
-              key         => 'F51A91A5EE001AA5D77D53C4C6E319C334410682',
-              include_src => false,
+              location => 'http://packages.icinga.com/ubuntu',
+              release  => "icinga-${::lsbdistcodename}",
+              repos    => 'main',
+              key      => {
+                id     => 'F51A91A5EE001AA5D77D53C4C6E319C334410682',
+                source => 'http://packages.icinga.com/icinga.key',
+              };
             }
           }
           default: {
@@ -71,32 +73,32 @@ class icinga2::repo {
       }
       'suse': {
 
-          file { '/etc/pki/GPG-KEY-icinga':
-            ensure => present,
-            source => 'http://packages.icinga.com/icinga.key',
-          }
+        file { '/etc/pki/GPG-KEY-icinga':
+          ensure => present,
+          source => 'http://packages.icinga.com/icinga.key',
+        }
 
-          exec { 'import icinga gpg key':
-            path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-            command   => 'rpm --import /etc/pki/GPG-KEY-icinga',
-            unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/GPG-KEY-icinga) | cut --characters=11-18 | tr [A-Z] [a-z]`",
-            require   => File['/etc/pki/GPG-KEY-icinga'],
-            logoutput => 'on_failure',
-          }
+        exec { 'import icinga gpg key':
+          path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+          command   => 'rpm --import /etc/pki/GPG-KEY-icinga',
+          unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/GPG-KEY-icinga) | cut --characters=11-18 | tr [A-Z] [a-z]`",
+          require   => File['/etc/pki/GPG-KEY-icinga'],
+          logoutput => 'on_failure',
+        }
 
-          case $::operatingsystem {
-            'SLES': {
-              zypprepo { 'icinga-stable-release':
-                baseurl  => "http://packages.icinga.com/SUSE/${::operatingsystemmajrelease}/release/",
-                enabled  => 1,
-                gpgcheck => 1,
-                require  => Exec['import icinga gpg key']
-              }
-            }
-            default: {
-              fail('Your plattform is not supported to manage a repository.')
+        case $::operatingsystem {
+          'SLES': {
+            zypprepo { 'icinga-stable-release':
+              baseurl  => "http://packages.icinga.com/SUSE/${::operatingsystemmajrelease}/release/",
+              enabled  => 1,
+              gpgcheck => 1,
+              require  => Exec['import icinga gpg key']
             }
           }
+          default: {
+            fail('Your plattform is not supported to manage a repository.')
+          }
+        }
       }
       'windows': {
         warning("The Icinga Project doesn't offer chocolaty packages at the moment.")

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.10.0 < 5.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.1 < 3.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 1.8.0 < 3.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 < 5.0.0" },
     { "name": "puppetlabs/chocolatey", "version_requirement": ">= 0.7.0 < 3.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.2 < 2.0.0" }
   ],


### PR DESCRIPTION
Remove deprecated apt::source options to maintain the compatibility w/ new apt released.

Version 4 of puppetlabs/apt is already incompatible.