### PR TITLE
Replace darin/zypprepo with puppet/zypprepo

### DIFF
--- a/.fixtures.puppet3.yml
+++ b/.fixtures.puppet3.yml
@@ -9,6 +9,6 @@ fixtures:
       repo: "puppetlabs/apt"
       ref: "2.4.0"
     chocolatey: "puppetlabs/chocolatey"
-    zypprepo: "darin/zypprepo"
+    zypprepo: "puppet/zypprepo"
   symlinks:
     icinga2: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,6 @@ fixtures:
     concat: "puppetlabs/concat"
     apt: "puppetlabs/apt"
     chocolatey: "puppetlabs/chocolatey"
-    zypprepo: "darin/zypprepo"
+    zypprepo: "puppet/zypprepo"
   symlinks:
     icinga2: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Depending on your setup following modules may also be required:
 
 * [puppetlabs/apt] >= 2.0.0
 * [puppetlabs/chocolatey] >= 0.7.0
-* [darin/zypprepo] >= 1.0.2
+* [puppet/zypprepo] >= 2.0.0
 
 ### Limitations
 
@@ -143,7 +143,7 @@ Make sure that you enable features **either** in the `::icinga2` class **or** by
 The IDO feature can be enabled either in combination with MySQL or PostgreSQL.
 
 Depending on your database you need to enable the feature `icinga2::feature::idomysql` or `icinga2::feature::idopgsql`.
- 
+
 Both features are capable of importing the base schema into the database, however this is disabled by default.
 Updating the database schema to another version is currently not supported.
 
@@ -588,7 +588,7 @@ include ::icinga2::feature::api
   * Save the certificate of another Icinga 2 instance, usually the Icinga master where your Icinga CA is located
   * Generate a ticket based on the TicketSalt
   * Request a signed certificate at your Icinga CA
-  
+
 ``` puppet
 class { '::icinga2::feature::api':
   pki             => 'icinga2',
@@ -1217,7 +1217,7 @@ Accept zone configuration. Defaults to `false`
 Accept remote commands. Defaults to `false`
 
 ##### `ca_host`
-This host will be connected to request the certificate. Set this if you use the `icinga2` pki. 
+This host will be connected to request the certificate. Set this if you use the `icinga2` pki.
 
 ##### `ca_port`
 Port of the 'ca_host'. Defaults to `5665`
@@ -2352,7 +2352,7 @@ See also [CHANGELOG.md]
 [puppetlabs/concat]: https://github.com/puppetlabs/puppetlabs-concat
 [puppetlabs/apt]: https://github.com/puppetlabs/puppetlabs-apt
 [puppetlabs/chocolatey]: https://github.com/puppetlabs/puppetlabs-chocolatey
-[darin/zypprepo]: https://forge.puppet.com/darin/zypprepo
+[puppet/zypprepo]: https://forge.puppet.com/puppet/zypprepo
 [puppetlabs/mysql]: https://github.com/puppetlabs/puppetlabs-mysql
 [puppetlabs/puppetlabs-postgresql]: https://github.com/puppetlabs/puppetlabs-postgresql
 [puppet-icinga2]: https://github.com/icinga/puppet-icinga2

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.1 < 3.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 < 5.0.0" },
     { "name": "puppetlabs/chocolatey", "version_requirement": ">= 0.7.0 < 3.0.0" },
-    { "name": "darin/zypprepo", "version_requirement": ">= 1.0.2 < 2.0.0" }
+    { "name": "puppet/zypprepo", "version_requirement": ">= 2.0.0 < 3.0.0" }
   ],
   "operatingsystem_support": [
     {

--- a/serverspec/environments/production/Puppetfile
+++ b/serverspec/environments/production/Puppetfile
@@ -7,7 +7,7 @@ mod 'puppetlabs/chocolatey', :latest
 mod 'puppetlabs/powershell', :latest
 mod 'puppetlabs/mysql', :latest
 mod 'badgerious/windows_env', :latest
-mod 'darin/zypprepo', :latest
+mod 'puppet/zypprepo', :latest
 mod 'icinga2',
   :git    => 'https://github.com/Icinga/puppet-icinga2.git',
   :branch => 'master'


### PR DESCRIPTION
Hi,

darin/zypprepo is no longer maintained and was previously deprecated. See https://github.com/voxpupuli/puppet-zypprepo/issues/15 for proof. 

The successor is https://forge.puppet.com/puppet/zypprepo which is maintained by the great guys from VoxPupuli. 
