### PR TITLE
Fix examples/init_confd.pp

### DIFF
--- a/examples/init_confd.pp
+++ b/examples/init_confd.pp
@@ -3,6 +3,7 @@ class { 'icinga2':
   confd       => '/etc/icinga/local.d',
 }
 
-file { '/etc/icinga2/conf.d/local.d':
+file { '/etc/icinga2/local.d':
   ensure => directory,
+  tag    => 'icinga2::config::file',
 }


### PR DESCRIPTION
> confd
>
> This is the directory where Icinga 2 stores it's object configuration by default. To disable this, set the parameter to false. It's also possible to assign your own directory. This directory is relative to etc/icinga2 and **must be managed outside of this module as file resource with tag icinga2::config::file**.

Also fix the path, I'm pretty sure it's supposed to match `confd`.

I don't use puppet and haven't tested this myself.