### PR TITLE
README.md: clarify meaning of `confd=>true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,9 +801,9 @@ Hash of constants. Defaults are set in the params class. Your settings will be m
 A list of the ITL plugins to load. Defaults to `[ 'plugins', 'plugins-contrib', 'windows-plugins', 'nscp' ]`.
 
 ##### `confd`
-This is the directory where Icinga 2 stores it's object configuration by default. To disable this, set the parameter
-to `false`. It's also possible to assign your own directory. This directory is relative to etc/icinga2 and must be
-managed outside of this module as file resource with tag icinga2::config::file. By default this parameter is `true`.
+`conf.d` is the directory where Icinga 2 stores its object configuration by default. To disable it, set this parameter
+to `false`. By default this parameter is `true`. It's also possible to assign your own directory. This directory is
+relative to /etc/icinga2 and must be managed outside of this module as file resource with tag icinga2::config::file. 
 
 #### Class: `icinga2::feature::checker`
 Enables or disables the `checker` feature.


### PR DESCRIPTION
It was made clear that you can enable or disable the confd directory, but it was not quite clear what puppet-icinga2 used as the default confd directory.

Particularly as there is a reference from the icinga manual, which I read as saying that puppet-icinga2 uses `objects.d` by default. Hence my confusion.

https://docs.icinga.com/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2-first-steps?highlight-search=puppet#your-configuration