### PR TITLE
handling node_name not equal to $::fqdn

### DIFF
--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -237,7 +237,7 @@ class icinga2::feature::api(
     validate_integer($bind_port)
   }
 
-
+  $cert_cn=$node_name
 
   # handle the certificate's stuff
   case $pki {
@@ -308,11 +308,11 @@ class icinga2::feature::api(
       validate_string($ca_host)
       validate_integer($ca_port)
 
-      $ticket_id = icinga2_ticket_id($::fqdn, $ticket_salt)
+      $ticket_id = icinga2_ticket_id($cert_cn, $ticket_salt)
       $trusted_cert = "${pki_dir}/trusted-cert.crt"
 
       exec { 'icinga2 pki create key':
-        command => "icinga2 pki new-cert --cn '${::fqdn}' --key '${_ssl_key_path}' --cert '${_ssl_cert_path}'",
+        command => "icinga2 pki new-cert --cn '${cert_cn}' --key '${_ssl_key_path}' --cert '${_ssl_cert_path}'",
         creates => $_ssl_key_path,
         notify  => Class['::icinga2::service'],
       }

--- a/manifests/pki/ca.pp
+++ b/manifests/pki/ca.pp
@@ -101,6 +101,8 @@ class icinga2::pki::ca(
   else {
     $_ssl_cacert_path = "${pki_dir}/ca.crt" }
 
+  $cert_cn=$node_name
+
   if !$ca_cert or !$ca_key {
     $path = $::osfamily ? {
       'windows' => 'C:/ProgramFiles/ICINGA2/sbin',
@@ -155,7 +157,7 @@ class icinga2::pki::ca(
   }
 
   exec { 'icinga2 pki create certificate signing request':
-    command => "icinga2 pki new-cert --cn '${::fqdn}' --key '${_ssl_key_path}' --csr '${_ssl_csr_path}'",
+    command => "icinga2 pki new-cert --cn '${cert_cn}' --key '${_ssl_key_path}' --csr '${_ssl_csr_path}'",
     creates => $_ssl_key_path,
     require => File[$_ssl_cacert_path]
   }


### PR DESCRIPTION
When setting NodeName into constants param resulting api certificate still use fqdn as common name.
Could you include this patch int your upstream version ?.