### PR TITLE
Allow creating vars += config by specifying -:+config as a vars string

### DIFF
--- a/lib/puppet_x/icinga2/utils.rb
+++ b/lib/puppet_x/icinga2/utils.rb
@@ -221,7 +221,11 @@ module Puppet
             elsif value.is_a?(Array)
               config += "%s%s = [ %s]\n" % [ ' ' * indent, attr, process_array(value) ]
             else
-              config += "%s%s = %s\n" % [ ' ' * indent, attr, parse(value) ]
+              if parse(value) == '+config'
+                config += "%s%s += config\n" % [ ' ' * indent, attr ]
+              else
+                config += "%s%s = %s\n" % [ ' ' * indent, attr, parse(value) ]
+              end
             end
           end
         end


### PR DESCRIPTION
Whilst not perfect, it solves a major issue.

Given more opportunity for thought, it could probably be done a lot better, but this works