### PR TITLE
Used combined constants instead of default to create cert with correct CN

### DIFF
--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -174,7 +174,7 @@ class icinga2::feature::api(
   $ca_dir        = $::icinga2::params::ca_dir
   $user          = $::icinga2::params::user
   $group         = $::icinga2::params::group
-  $node_name     = $::icinga2::_constants['NodeName']
+  $node_name     = $::icinga2::constants['NodeName']
   $_ssl_key_mode = $::osfamily ? {
     'windows' => undef,
     default   => '0600',

--- a/manifests/pki/ca.pp
+++ b/manifests/pki/ca.pp
@@ -68,7 +68,7 @@ class icinga2::pki::ca(
   $pki_dir   = $::icinga2::params::pki_dir
   $user      = $::icinga2::params::user
   $group     = $::icinga2::params::group
-  $node_name = $::icinga2::_constants['NodeName']
+  $node_name = $::icinga2::constants['NodeName']
 
   File {
     owner => $user,


### PR DESCRIPTION
Making sure that for setup that is using custom node name instead of fqdn certificates are generated with that name.