### PR TITLE
Fix dependency issues with apt repository

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,17 +177,19 @@ class icinga2(
   -> Concat <| tag == 'icinga2::config::file' |>
   ~> Class['::icinga2::service']
 
+  # Put ::icinga2::repo outside to work around dependency cycle issues with the apt module
+  include '::icinga2::repo'
+
   anchor { '::icinga2::begin':
-    notify => Class['::icinga2::service']
+    notify => Class['::icinga2::service'],
   }
-  -> class { '::icinga2::repo': }
   -> class { '::icinga2::install': }
   -> File <| ensure == 'directory' and tag == 'icinga2::config::file' |>
   -> class { '::icinga2::config': notify => Class['::icinga2::service'] }
   -> File <| ensure != 'directory' and tag == 'icinga2::config::file' |>
   ~> class { '::icinga2::service': }
   -> anchor { '::icinga2::end':
-    subscribe => Class['::icinga2::config']
+    subscribe => Class['::icinga2::config'],
   }
 
   include prefix($features, '::icinga2::feature::')

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -31,6 +31,8 @@ class icinga2::repo {
               gpgcheck => 1,
               gpgkey   => 'http://packages.icinga.com/icinga.key',
             }
+
+            Yumrepo['icinga-stable-release'] -> Package<|tag == 'icinga2'|>
           }
           default: {
             fail('Your plattform is not supported to manage a repository.')
@@ -41,6 +43,7 @@ class icinga2::repo {
         # handle icinga stable repo before all package resources
         # contain class problem!
         Apt::Source['icinga-stable-release'] -> Package <| tag == 'icinga2' |>
+        Class['Apt::Update'] -> Package<|tag == 'icinga2'|>
         case $::operatingsystem {
           'debian': {
             include ::apt, ::apt::backports
@@ -76,7 +79,7 @@ class icinga2::repo {
       'suse': {
 
         file { '/etc/pki/GPG-KEY-icinga':
-          ensure => present,
+          ensure => file,
           source => 'http://packages.icinga.com/icinga.key',
         }
 
@@ -94,8 +97,10 @@ class icinga2::repo {
               baseurl  => "http://packages.icinga.com/SUSE/${::operatingsystemmajrelease}/release/",
               enabled  => 1,
               gpgcheck => 1,
-              require  => Exec['import icinga gpg key']
+              require  => Exec['import icinga gpg key'],
             }
+
+            Zypprepo['icinga-stable-release'] -> Package <| tag == 'icinga2' |>
           }
           default: {
             fail('Your plattform is not supported to manage a repository.')


### PR DESCRIPTION
This is needed as there is currently no dependency between the
icinga2 packages and Class['apt::update']. This can lead to problems
where the package is installed before apt knowns of the repository.

It also removes the anchor usage of the icinga2::repo class and moves
the dependency management to icinga::repo itself. This is needed as
other modules might also add apt repositories and require
Class['apt::update']. When using the anchor pattern this breaks as
it introduces a dependency cycle.