### PR TITLE
Add purge_conf_dir feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,9 @@ A list of features to enable by default. Defaults to `[checker, mainlog, notific
 ##### `purge_features`
 Define if configuration files for features not managed by Puppet should be purged. Defaults to true.
 
+##### `purge_conf_dir`
+Define if files within the central configuration dir (e.g. /etc/icinga2/) which aren't managed by Puppet should be purged. Defaults to false.
+
 ##### `constants`
 Hash of constants. Defaults are set in the params class. Your settings will be merged with the defaults.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,9 @@
 # [*purge_features*]
 #   Define if configuration files for features not managed by Puppet should be purged. Defaults to true.
 #
+# [*purge_conf_dir*]
+#   Define if files within the central configuration dir (e.g. /etc/icinga2/) which aren't managed by Puppet should be purged. Defaults to false.
+#
 # [*constants*]
 #   Hash of constants. Defaults are set in the params class. Your settings will be merged with the defaults.
 #
@@ -145,6 +148,7 @@ class icinga2(
   $manage_service = true,
   $features       = $icinga2::params::default_features,
   $purge_features = true,
+  $purge_conf_dir = false,
   $constants      = {},
   $plugins        = $icinga2::params::plugins,
   $confd          = true,
@@ -158,6 +162,7 @@ class icinga2(
   validate_bool($manage_service)
   validate_array($features)
   validate_bool($purge_features)
+  validate_bool($purge_conf_dir)
   validate_hash($constants)
   validate_array($plugins)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,6 +20,7 @@ class icinga2::install {
   $manage_package = $::icinga2::manage_package
   $pki_dir        = $::icinga2::params::pki_dir
   $conf_dir       = $::icinga2::params::conf_dir
+  $purge_conf_dir = $::icinga2::purge_conf_dir
   $user           = $::icinga2::params::user
   $group          = $::icinga2::params::group
 
@@ -33,9 +34,12 @@ class icinga2::install {
   }
 
   file { [$pki_dir, $conf_dir]:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
+    ensure  => directory,
+    owner   => $user,
+    group   => $group,
+    purge   => $purge_conf_dir,
+    recurse => $purge_conf_dir,
+    force   => $purge_conf_dir,
   }
 }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,11 +13,13 @@ describe('icinga2', :type => :class) do
         before(:all) do
           @icinga2_conf = '/etc/icinga2/icinga2.conf'
           @constants_conf = '/etc/icinga2/constants.conf'
+					@conf_dir = '/etc/icinga2'
         end
       when 'FreeBSD'
         before(:all) do
           @icinga2_conf = '/usr/local/etc/icinga2/icinga2.conf'
           @constants_conf = '/usr/local/etc/icinga2/constants.conf'
+					@conf_dir = '/usr/local/etc/icinga2'
         end
       end
 
@@ -94,6 +96,9 @@ describe('icinga2', :type => :class) do
         it { is_expected.to contain_icinga2__feature('notification')
           .with({'ensure' => 'present'}) }
 
+        it { is_expected.to contain_file(@conf_dir)
+					.with({'ensure'  => 'directory',})}
+
         case facts[:osfamily]
         when 'Debian'
           it { should_not contain_apt__source('icinga-stable-release') }
@@ -107,6 +112,16 @@ describe('icinga2', :type => :class) do
           let(:params) { {:manage_package => false} }
 
           it { should_not contain_package('icinga2').with({ 'ensure' => 'installed' }) }
+        end
+
+        context "#{os} with purge_conf_dir => true" do
+          let(:params) { {:purge_conf_dir => true} }
+
+          it { should contain_file(@conf_dir).with({
+						'ensure'  => 'directory',
+						'purge'   => true,
+						'recurse' => true,
+						'force'   => true })}
         end
       end
     end
@@ -135,6 +150,7 @@ describe('icinga2', :type => :class) do
   before(:all) do
     @icinga2_conf = "C:/ProgramData/icinga2/etc/icinga2/icinga2.conf"
     @constants_conf = "C:/ProgramData/icinga2/etc/icinga2/constants.conf"
+		@conf_dir = 'C:/ProgramData/icinga2/etc/icinga2'
   end
 
   context 'Windows 2012 R2 with all default parameters' do
@@ -195,12 +211,25 @@ describe('icinga2', :type => :class) do
 
     it { is_expected.to contain_icinga2__feature('notification')
                             .with({'ensure' => 'present'}) }
+
+    it { is_expected.to contain_file(@conf_dir)
+														.with({'ensure'  => 'directory',})}
   end
 
   context "Windows 2012 R2 with manage_package => false" do
     let(:params) { {:manage_package => false} }
 
     it { should_not contain_package('icinga2').with({ 'ensure' => 'installed' }) }
+  end
+
+  context "Windows 2012 R2 with purge_conf_dir => true" do
+    let(:params) { {:purge_conf_dir => true} }
+
+    it { should contain_file(@conf_dir).with({
+			'ensure'  => 'directory',
+			'purge'   => true,
+			'recurse' => true,
+			'force'   => true })}
   end
 end
 


### PR DESCRIPTION
This PR adds support for purging the complete configuration directory (e.g. /etc/icinga2) of Icinga2. This is really helpful if you want to ensure that everything inside it is managed by Puppet.

This feature is disable by default as it would probably break setups in the wild.