### PR TITLE
Replace validate_* with data types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ pkg/
 Gemfile.lock
 /.ruby-*
 .bundle
+.vendor/
 vendor/
+log/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ matrix:
   fast_finish: true
   include:
     - rvm: 2.4.0
-      env: PUPPET_VERSION="~> 5.0" CHECK=test
+      env: PUPPET_VERSION="~> 5.0" CHECK=test PARALLEL_TEST_PROCESSORS=4
     - rvm: 2.3.3
-      env: PUPPET_VERSION="~> 4.0" CHECK=test
+      env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=4
     - rvm: 2.2.6
-      env: PUPPET_VERSION="~> 4.0" CHECK=test
-    - rvm: 2.1.10
-      env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
+      env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=4
     - rvm: 2.1.10
       env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=4
+    - rvm: 2.1.10
+      env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
   allow_failures:
     - rvm: 2.4.0
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache: bundler
 before_install:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system
-  - gem update bundler
   - gem --version
   - bundle -v
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,28 +17,22 @@ env:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.4.0
-    env: PUPPET_VERSION="~> 5.0" CHECK=test
-  - rvm: 2.3.3
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.2.6
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.1.10
-    env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
-  - rvm: 2.1.10
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.1.10
-    env: PUPPET_VERSION="~> 3.8" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test FIXTURES_YML=.fixtures.puppet3.yml
-  - rvm: 2.1.10
-    env: PUPPET_VERSION="~> 3.8" STRICT_VARIABLES="yes" CHECK=test FIXTURES_YML=.fixtures.puppet3.yml
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.8" STRICT_VARIABLES="yes" CHECK=test FIXTURES_YML=.fixtures.puppet3.yml
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.8" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test FIXTURES_YML=.fixtures.puppet3.yml
+    - rvm: 2.4.0
+      env: PUPPET_VERSION="~> 5.0" CHECK=test
+    - rvm: 2.3.3
+      env: PUPPET_VERSION="~> 4.0" CHECK=test
+    - rvm: 2.2.6
+      env: PUPPET_VERSION="~> 4.0" CHECK=test
+    - rvm: 2.1.10
+      env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
+    - rvm: 2.1.10
+      env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=4
+  allow_failures:
+    - rvm: 2.4.0
 branches:
   only:
-  - master
-  - /^v\d/
+    - master
+    - /^v\d/
 notifications:
   email: false
 deploy:

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Alan Jenkins <alan.christopher.jenkins@gmail.com>
 Alessandro Lorenzi <alessandro@lm-net.it>
 Alexander Schaber <alexander@schaber.info>
+Andrea Cervesato <andrea.cervesato@kqi.it>
 Andreas Ntaflos <andreas.ntaflos@rise-world.com>
 Andreas Paul <xorpaul@gmail.com>
 Blerim Sheqa <blerim.sheqa@icinga.com>
@@ -21,6 +22,8 @@ Rudy Gevaert <rudy.gevaert@ugent.be>
 Simon Hoenscheid <simon.hoenscheid@netways.de>
 Stefan Kleindl <stefan.kleindl@rise-world.com>
 Thomas Dalichow <thomas.dalichow@publicispixelpark.de>
+Till Adam <till.adam@dm.de>
 Tom De Vylder <tom@penumbra.be>
 Tomas Barton <barton.tomas@gmail.com>
+Wyatt Alt <wyatt.alt@gmail.com>
 Zach Leslie <xaque208@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Change Log
 
+## [v1.3.5](https://github.com/Icinga/puppet-icinga2/tree/v1.3.5) (2018-01-24)
+[Full Changelog](https://github.com/Icinga/puppet-icinga2/compare/v1.3.4...v1.3.5)
+
+**Implemented enhancements:**
+
+- icinga2 binary is wrong on rhel5 [\#409](https://github.com/Icinga/puppet-icinga2/issues/409)
+- Add feature Elasticsearch [\#408](https://github.com/Icinga/puppet-icinga2/issues/408)
+- Add feature elasticsearch [\#399](https://github.com/Icinga/puppet-icinga2/issues/399)
+- Added cloudlinux to supported operating systems. Is nearly identical … [\#424](https://github.com/Icinga/puppet-icinga2/pull/424) ([koma85](https://github.com/koma85))
+
+**Fixed bugs:**
+
+- Setting up icinga2 with a different port than default for idodb leads to an error  [\#411](https://github.com/Icinga/puppet-icinga2/issues/411)
+- fix \#411 Setting up Icinga 2 with a different port than default for i… [\#413](https://github.com/Icinga/puppet-icinga2/pull/413) ([lbetz](https://github.com/lbetz))
+- fix for repository.d directory on master-systems [\#412](https://github.com/Icinga/puppet-icinga2/pull/412) ([matthiasritter](https://github.com/matthiasritter))
+
+**Closed issues:**
+
+- escaping broken with double quotes? [\#416](https://github.com/Icinga/puppet-icinga2/issues/416)
+- Icinga resource doesn't create ca directory and required files [\#415](https://github.com/Icinga/puppet-icinga2/issues/415)
+- icinga2 option generates self signed certificates that are rejected by master [\#405](https://github.com/Icinga/puppet-icinga2/issues/405)
+- manage repo trough proxy [\#394](https://github.com/Icinga/puppet-icinga2/issues/394)
+
+**Merged pull requests:**
+
+- trivial copy edits [\#420](https://github.com/Icinga/puppet-icinga2/pull/420) ([wkalt](https://github.com/wkalt))
+- Fix confd example path [\#417](https://github.com/Icinga/puppet-icinga2/pull/417) ([dnsmichi](https://github.com/dnsmichi))
+- fix \#409 icinga2 binary is wrong on rhel5 [\#410](https://github.com/Icinga/puppet-icinga2/pull/410) ([lbetz](https://github.com/lbetz))
+
 ## [v1.3.4](https://github.com/Icinga/puppet-icinga2/tree/v1.3.4) (2017-11-22)
 [Full Changelog](https://github.com/Icinga/puppet-icinga2/compare/v1.3.3...v1.3.4)
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ available in Icinga 2 can be enabled and configured with this module.
 
 This module depends on:
 
-* [puppetlabs/stdlib] >= 4.10.0
-* [puppetlabs/concat] >= 2.0.1
+* [puppetlabs/stdlib] >= 4.16.0
+* [puppetlabs/concat] >= 2.1.0
 
 Depending on your setup following modules may also be required:
 

--- a/examples/example4/profile/manifests/agent.pp
+++ b/examples/example4/profile/manifests/agent.pp
@@ -1,18 +1,16 @@
 # Notice: this code contains Puppet 4 syntax! It doesn't run on Puppet 3.
 class profile::icinga2::agent(
-  $parent_endpoints,
-  $parent_zone,
-  $agent_ip = $::ipaddress,
+  Hash                       $parent_endpoints,
+  String                     $parent_zone,
+  Stdlib::Compat::Ip_address $agent_ip = $::ipaddress,
 ) {
 
   contain ::profile::icinga2::plugins
 
-  validate_hash($parent_endpoints)
-
   class { '::icinga2':
     manage_repo => true,
     confd       => false,
-    features  => ['mainlog'],
+    features    => ['mainlog'],
   }
 
   # Feature: api
@@ -23,8 +21,8 @@ class profile::icinga2::agent(
       'ZoneName' => {
         'endpoints' => [ 'NodeName' ],
         'parent'    => $parent_zone,
-      }
-    }
+      },
+    },
   }
 
   ::icinga2::object::zone { 'linux-commands':

--- a/examples/example4/profile/manifests/slave.pp
+++ b/examples/example4/profile/manifests/slave.pp
@@ -1,22 +1,20 @@
 # Notice: this code contains Puppet 4 syntax! It doesn't run on Puppet 3.
 class profile::icinga2::slave(
-  $slave_zone,
-  $parent_endpoints,
-  $parent_zone = 'master',
-  $slave_ip = $::ipaddress,
+  String                     $slave_zone,
+  Array                      $parent_endpoints,
+  String                     $parent_zone = 'master',
+  Stdlib::Compat::Ip_address $slave_ip = $::ipaddress,
 ) {
 
   contain ::profile::icinga2::plugins
 
-  validate_array($parent_endpoints)
-
   class { '::icinga2':
     manage_repo => true,
     confd       => false,
-    features  => ['checker','mainlog'],
+    features    => ['checker','mainlog'],
     constants   => {
       'ZoneName' => $slave_zone,
-    }
+    },
   }
 
   # Feature: api
@@ -27,8 +25,8 @@ class profile::icinga2::slave(
       'ZoneName' => {
         'endpoints' => [ 'NodeName' ],
         'parent'    => $parent_zone,
-      }
-    }
+      },
+    },
   }
 
   ::icinga2::object::endpoint { $parent_endpoints: }

--- a/lib/puppet_x/icinga2/utils.rb
+++ b/lib/puppet_x/icinga2/utils.rb
@@ -86,7 +86,7 @@ module Puppet
 
         def self.value_types(value)
 
-          if value =~ /^\d+\.?\d*[dhms]?$/ || value =~ /^(true|false)$/ || value =~ /^!?(host|service|user)\./ || value =~ /^\{{2}.*\}{2}$/
+          if value =~ /^\d+\.?\d*[dhms]?$/ || value =~ /^(true|false|null)$/ || value =~ /^!?(host|service|user)\./ || value =~ /^\{{2}.*\}{2}$/
             result = value
           else
             if $constants.index { |x| if $hash_attrs.include?(x) then value =~ /^!?(#{x})(\..+$|$)/ else value =~ /^!?#{x}$/ end }

--- a/manifests/config/fragment.pp
+++ b/manifests/config/fragment.pp
@@ -16,10 +16,10 @@
 #
 #
 define icinga2::config::fragment(
-  $content,
-  $target,
-  $code_name = $title,
-  $order     = '0',
+  String               $content,
+  Stdlib::Absolutepath $target,
+  String               $code_name = $title,
+  Pattern[/^\d+$/]     $order     = '0',
 ) {
 
   include ::icinga2::params
@@ -43,10 +43,6 @@ define icinga2::config::fragment(
       $_content = $content
     } # default
   }
-
-  validate_string($content)
-  validate_absolute_path($target)
-  validate_string($order)
 
   if !defined(Concat[$target]) {
     concat { $target:

--- a/manifests/debian/dbconfig.pp
+++ b/manifests/debian/dbconfig.pp
@@ -1,25 +1,16 @@
 # == Class: icinga2::debian::dbconfig
 #
 class icinga2::debian::dbconfig(
-  $dbtype,
-  $dbserver,
-  $dbport,
-  $dbname,
-  $dbuser,
-  $dbpass,
-  $ssl = false,
+  Enum['mysql', 'pgsql'] $dbtype,
+  String                 $dbserver,
+  Integer[1,65535]       $dbport,
+  String                 $dbname,
+  String                 $dbuser,
+  String                 $dbpass,
+  Boolean                $ssl = false,
 ) {
 
   assert_private()
-
-  validate_re($dbtype, [ '^mysql$', '^pgsql$' ],
-    "${dbtype} isn't supported. Valid values are 'mysql' and 'pgsql'.")
-  validate_string($dbserver)
-  validate_integer($dbport)
-  validate_string($dbname)
-  validate_string($dbuser)
-  validate_string($dbpass)
-  validate_bool($ssl)
 
   # dbconfig config for Debian or Ubuntu
   if $::osfamily == 'debian' {

--- a/manifests/feature.pp
+++ b/manifests/feature.pp
@@ -4,14 +4,11 @@
 #
 #
 define icinga2::feature(
-  $ensure  = present,
-  $feature = $title,
+  Enum['absent', 'present'] $ensure  = present,
+  String                    $feature = $title,
 ) {
 
   assert_private()
-
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
 
   $user     = $::icinga2::params::user
   $group    = $::icinga2::params::group

--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -141,26 +141,26 @@
 #
 #
 class icinga2::feature::api(
-  $ensure          = present,
-  $pki             = 'puppet',
-  $ssl_key_path    = undef,
-  $ssl_cert_path   = undef,
-  $ssl_csr_path    = undef,
-  $ssl_cacert_path = undef,
-  $accept_config   = false,
-  $accept_commands = false,
-  $ca_host         = undef,
-  $ca_port         = 5665,
-  $ticket_salt     = 'TicketSalt',
-  $endpoints       = { 'NodeName' => {} },
-  $zones           = { 'ZoneName' => { endpoints => [ 'NodeName' ] } },
-  $ssl_key         = undef,
-  $ssl_cert        = undef,
-  $ssl_cacert      = undef,
-  $ssl_protocolmin = undef,
-  $ssl_cipher_list = undef,
-  $bind_host       = undef,
-  $bind_port       = undef,
+  Enum['absent', 'present']               $ensure          = present,
+  Enum['ca', 'icinga2', 'none', 'puppet'] $pki             = 'puppet',
+  Optional[Stdlib::Absolutepath]          $ssl_key_path    = undef,
+  Optional[Stdlib::Absolutepath]          $ssl_cert_path   = undef,
+  Optional[Stdlib::Absolutepath]          $ssl_csr_path    = undef,
+  Optional[Stdlib::Absolutepath]          $ssl_cacert_path = undef,
+  Boolean                                 $accept_config   = false,
+  Boolean                                 $accept_commands = false,
+  Optional[String]                        $ca_host         = undef,
+  Integer[1,65535]                        $ca_port         = 5665,
+  String                                  $ticket_salt     = 'TicketSalt',
+  Hash                                    $endpoints       = { 'NodeName' => {} },
+  Hash                                    $zones           = { 'ZoneName' => { endpoints => [ 'NodeName' ] } },
+  Optional[String]                        $ssl_key         = undef,
+  Optional[String]                        $ssl_cert        = undef,
+  Optional[String]                        $ssl_cacert      = undef,
+  Optional[String]                        $ssl_protocolmin = undef,
+  Optional[String]                        $ssl_cipher_list = undef,
+  Optional[String]                        $bind_host       = undef,
+  Optional[Integer[1,65535]]              $bind_port       = undef,
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -192,53 +192,23 @@ class icinga2::feature::api(
     group => $group,
   }
 
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_re($pki, [ '^puppet$', '^none$', '^icinga2', '^ca' ],
-    "${pki} isn't supported. Valid values are 'puppet', 'none', 'icinga2' and 'ca (deprecated)'.")
-  validate_bool($accept_config)
-  validate_bool($accept_commands)
-  validate_string($ticket_salt)
-  validate_hash($endpoints)
-  validate_hash($zones)
-
-  # Set defaults for certificate stuff and/or do validation
+  # Set defaults for certificate stuff
   if $ssl_key_path {
-    validate_absolute_path($ssl_key_path)
     $_ssl_key_path = $ssl_key_path }
   else {
     $_ssl_key_path = "${pki_dir}/${node_name}.key" }
   if $ssl_cert_path {
-    validate_absolute_path($ssl_cert_path)
     $_ssl_cert_path = $ssl_cert_path }
   else {
     $_ssl_cert_path = "${pki_dir}/${node_name}.crt" }
   if $ssl_csr_path {
-    validate_absolute_path($ssl_csr_path)
     $_ssl_csr_path = $ssl_csr_path }
   else {
     $_ssl_csr_path = "${pki_dir}/${node_name}.csr" }
   if $ssl_cacert_path {
-    validate_absolute_path($ssl_cacert_path)
     $_ssl_cacert_path = $ssl_cacert_path }
   else {
     $_ssl_cacert_path = "${pki_dir}/ca.crt" }
-
-  if $ssl_protocolmin {
-    validate_string($ssl_protocolmin)
-  }
-  if $ssl_cipher_list {
-    validate_string($ssl_cipher_list)
-  }
-  if $bind_host {
-    validate_string($bind_host)
-  }
-  if $bind_port {
-    validate_integer($bind_port)
-  }
-
-
 
   # handle the certificate's stuff
   case $pki {
@@ -313,10 +283,6 @@ class icinga2::feature::api(
 
     'icinga2': {
       $_ticket_salt = undef
-
-      validate_string($ca_host)
-      validate_integer($ca_port)
-
       $ticket_id = icinga2_ticket_id($node_name, $ticket_salt)
       $trusted_cert = "${pki_dir}/trusted-cert.crt"
 

--- a/manifests/feature/checker.pp
+++ b/manifests/feature/checker.pp
@@ -12,8 +12,8 @@
 #
 #
 class icinga2::feature::checker(
-  $ensure            = present,
-  $concurrent_checks = undef,
+  Enum['absent', 'present'] $ensure            = present,
+  Optional[Integer[1]]      $concurrent_checks = undef,
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -25,12 +25,6 @@ class icinga2::feature::checker(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-
-  if $concurrent_checks { validate_integer($concurrent_checks) }
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/command.pp
+++ b/manifests/feature/command.pp
@@ -13,8 +13,8 @@
 #
 #
 class icinga2::feature::command(
-  $ensure       = present,
-  $command_path = "${::icinga2::params::run_dir}/cmd/icinga2.cmd",
+  Enum['absent', 'present'] $ensure       = present,
+  Stdlib::Absolutepath      $command_path = "${::icinga2::params::run_dir}/cmd/icinga2.cmd",
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -26,10 +26,6 @@ class icinga2::feature::command(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_absolute_path($command_path)
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/compatlog.pp
+++ b/manifests/feature/compatlog.pp
@@ -17,9 +17,9 @@
 #
 #
 class icinga2::feature::compatlog(
-  $ensure          = present,
-  $log_dir         = "${::icinga2::params::log_dir}/compat",
-  $rotation_method = 'DAILY',
+  Enum['absent', 'present']                    $ensure          = present,
+  Stdlib::Absolutepath                         $log_dir         = "${::icinga2::params::log_dir}/compat",
+  Enum['DAILY', 'HOURLY', 'MONTHLY', 'WEEKLY'] $rotation_method = 'DAILY',
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -31,12 +31,6 @@ class icinga2::feature::compatlog(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_absolute_path($log_dir)
-  validate_re($rotation_method, ['^HOURLY$','^DAILY$','^WEEKLY$','^MONTHLY$'])
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/debuglog.pp
+++ b/manifests/feature/debuglog.pp
@@ -14,8 +14,8 @@
 #
 #
 class icinga2::feature::debuglog(
-  $ensure   = present,
-  $path     = "${::icinga2::params::log_dir}/debug.log",
+  Enum['absent', 'present'] $ensure   = present,
+  Stdlib::Absolutepath      $path     = "${::icinga2::params::log_dir}/debug.log",
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -27,11 +27,6 @@ class icinga2::feature::debuglog(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_absolute_path($path)
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/gelf.pp
+++ b/manifests/feature/gelf.pp
@@ -21,11 +21,11 @@
 #
 #
 class icinga2::feature::gelf(
-  $ensure               = present,
-  $host                 = '127.0.0.1',
-  $port                 = '12201',
-  $source               = 'icinga2',
-  $enable_send_perfdata = false,
+  Enum['absent', 'present'] $ensure               = present,
+  String                    $host                 = '127.0.0.1',
+  Integer[1,65535]          $port                 = 12201,
+  String                    $source               = 'icinga2',
+  Boolean                   $enable_send_perfdata = false,
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -37,14 +37,6 @@ class icinga2::feature::gelf(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($host)
-  validate_integer($port)
-  validate_string($source)
-  validate_bool($enable_send_perfdata)
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/graphite.pp
+++ b/manifests/feature/graphite.pp
@@ -27,13 +27,13 @@
 #
 #
 class icinga2::feature::graphite(
-  $ensure                 = present,
-  $host                   = '127.0.0.1',
-  $port                   = '2003',
-  $host_name_template     = 'icinga2.$host.name$.host.$host.check_command$',
-  $service_name_template  = 'icinga2.$host.name$.services.$service.name$.$service.check_command$',
-  $enable_send_thresholds = false,
-  $enable_send_metadata   = false,
+  Enum['absent', 'present'] $ensure                 = present,
+  String                    $host                   = '127.0.0.1',
+  Integer[1,65535]          $port                   = 2003,
+  String                    $host_name_template     = 'icinga2.$host.name$.host.$host.check_command$',
+  String                    $service_name_template  = 'icinga2.$host.name$.services.$service.name$.$service.check_command$',
+  Boolean                   $enable_send_thresholds = false,
+  Boolean                   $enable_send_metadata   = false,
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -45,16 +45,6 @@ class icinga2::feature::graphite(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($host)
-  validate_integer($port)
-  validate_string($host_name_template)
-  validate_string($service_name_template)
-  validate_bool($enable_send_thresholds)
-  validate_bool($enable_send_metadata)
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/idomysql.pp
+++ b/manifests/feature/idomysql.pp
@@ -122,31 +122,31 @@
 #
 #
 class icinga2::feature::idomysql(
-  $ensure                 = present,
-  $host                   = '127.0.0.1',
-  $port                   = 3306,
-  $socket_path            = undef,
-  $user                   = 'icinga',
-  $password               = 'icinga',
-  $database               = 'icinga',
-  $enable_ssl             = false,
-  $pki                    = 'puppet',
-  $ssl_key_path           = undef,
-  $ssl_cert_path          = undef,
-  $ssl_cacert_path        = undef,
-  $ssl_key                = undef,
-  $ssl_cert               = undef,
-  $ssl_cacert             = undef,
-  $ssl_capath             = undef,
-  $ssl_cipher             = undef,
-  $table_prefix           = 'icinga_',
-  $instance_name          = 'default',
-  $instance_description   = undef,
-  $enable_ha              = true,
-  $failover_timeout       = '60s',
-  $cleanup                = undef,
-  $categories             = undef,
-  $import_schema          = false,
+  Enum['absent', 'present']      $ensure                 = present,
+  String                         $host                   = '127.0.0.1',
+  Integer[1,65535]               $port                   = 3306,
+  Optional[Stdlib::Absolutepath] $socket_path            = undef,
+  String                         $user                   = 'icinga',
+  String                         $password               = 'icinga',
+  String                         $database               = 'icinga',
+  Boolean                        $enable_ssl             = false,
+  Enum['none', 'puppet']         $pki                    = 'puppet',
+  Optional[Stdlib::Absolutepath] $ssl_key_path           = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cert_path          = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cacert_path        = undef,
+  Optional[String]               $ssl_key                = undef,
+  Optional[String]               $ssl_cert               = undef,
+  Optional[String]               $ssl_cacert             = undef,
+  Optional[Stdlib::Absolutepath] $ssl_capath             = undef,
+  Optional[String]               $ssl_cipher             = undef,
+  String                         $table_prefix           = 'icinga_',
+  String                         $instance_name          = 'default',
+  Optional[String]               $instance_description   = undef,
+  Boolean                        $enable_ha              = true,
+  Pattern[/^\d+[ms]*$/]          $failover_timeout       = '60s',
+  Optional[Hash]                 $cleanup                = undef,
+  Optional[Array]                $categories             = undef,
+  Boolean                        $import_schema          = false,
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -175,41 +175,16 @@ class icinga2::feature::idomysql(
     group   => $group,
   }
 
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($host)
-  validate_integer($port)
-  if $socket_path { validate_absolute_path($socket_path) }
-  validate_string($user)
-  validate_string($password)
-  validate_string($database)
-  validate_bool($enable_ssl)
-  validate_re($pki, [ '^puppet$', '^none$' ],
-    "${pki} isn't supported. Valid values are 'puppet' and 'none'.")
-  validate_string($table_prefix)
-  validate_string($instance_name)
-  if $instance_description { validate_string($instance_description) }
-  validate_bool($enable_ha)
-  validate_re($failover_timeout, '^\d+[ms]*$')
-  if $cleanup { validate_hash($cleanup) }
-  if $categories { validate_array($categories) }
-  validate_bool($import_schema)
-  if $ssl_capath { validate_absolute_path($ssl_capath) }
-  if $ssl_cipher { validate_string($ssl_cipher) }
-
-  # Set defaults for certificate stuff and/or do validation
+  # Set defaults for certificate stuff
   if $ssl_key_path {
-    validate_absolute_path($ssl_key_path)
-    $_ssl_key_path = $ssl_key_path }
+    $_ssl_key_path = $ssl_key_path}
   else {
     $_ssl_key_path = "${ssl_dir}/${node_name}.key" }
   if $ssl_cert_path {
-    validate_absolute_path($ssl_cert_path)
     $_ssl_cert_path = $ssl_cert_path }
   else {
     $_ssl_cert_path = "${ssl_dir}/${node_name}.crt" }
   if $ssl_cacert_path {
-    validate_absolute_path($ssl_cacert_path)
     $_ssl_cacert_path = $ssl_cacert_path }
   else {
     $_ssl_cacert_path = "${ssl_dir}/ca.crt" }

--- a/manifests/feature/idopgsql.pp
+++ b/manifests/feature/idopgsql.pp
@@ -71,20 +71,20 @@
 #
 #
 class icinga2::feature::idopgsql(
-  $ensure                 = present,
-  $host                   = '127.0.0.1',
-  $port                   = 5432,
-  $user                   = 'icinga',
-  $password               = 'icinga',
-  $database               = 'icinga',
-  $table_prefix           = 'icinga_',
-  $instance_name          = 'default',
-  $instance_description   = undef,
-  $enable_ha              = true,
-  $failover_timeout       = '60s',
-  $cleanup                = undef,
-  $categories             = undef,
-  $import_schema          = false,
+  Enum['absent', 'present'] $ensure                 = present,
+  String                    $host                   = '127.0.0.1',
+  Integer[1,65535]          $port                   = 5432,
+  String                    $user                   = 'icinga',
+  String                    $password               = 'icinga',
+  String                    $database               = 'icinga',
+  String                    $table_prefix           = 'icinga_',
+  String                    $instance_name          = 'default',
+  Optional[String]          $instance_description   = undef,
+  Boolean                   $enable_ha              = true,
+  Pattern[/^\d+[ms]*$/]     $failover_timeout       = '60s',
+  Optional[Hash]            $cleanup                = undef,
+  Optional[Array]           $categories             = undef,
+  Boolean                   $import_schema          = false,
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -99,22 +99,6 @@ class icinga2::feature::idopgsql(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($host)
-  validate_integer($port)
-  validate_string($user)
-  validate_string($password)
-  validate_string($database)
-  validate_string($table_prefix)
-  validate_string($instance_name)
-  if $instance_description { validate_string($instance_description) }
-  validate_bool($enable_ha)
-  validate_re($failover_timeout, '^\d+[ms]*$')
-  if $cleanup { validate_hash($cleanup) }
-  if $categories { validate_array($categories) }
-  validate_bool($import_schema)
 
   $attrs = {
     host                  => $host,

--- a/manifests/feature/influxdb.pp
+++ b/manifests/feature/influxdb.pp
@@ -97,28 +97,28 @@
 #
 #
 class icinga2::feature::influxdb(
-  $ensure                 = present,
-  $host                   = '127.0.0.1',
-  $port                   = 8086,
-  $database               = 'icinga2',
-  $username               = undef,
-  $password               = undef,
-  $enable_ssl             = false,
-  $pki                    = 'puppet',
-  $ssl_key_path           = undef,
-  $ssl_cert_path          = undef,
-  $ssl_cacert_path        = undef,
-  $ssl_key                = undef,
-  $ssl_cert               = undef,
-  $ssl_cacert             = undef,
-  $host_measurement       = '$host.check_command$',
-  $host_tags              = { hostname => '$host.name$' },
-  $service_measurement    = '$service.check_command$',
-  $service_tags           = { hostname => '$host.name$', service => '$service.name$' },
-  $enable_send_thresholds = false,
-  $enable_send_metadata   = false,
-  $flush_interval         = '10s',
-  $flush_threshold        = 1024
+  Enum['absent', 'present']      $ensure                 = present,
+  String                         $host                   = '127.0.0.1',
+  Integer[1,65535]               $port                   = 8086,
+  String                         $database               = 'icinga2',
+  Optional[String]               $username               = undef,
+  Optional[String]               $password               = undef,
+  Boolean                        $enable_ssl             = false,
+  Enum['none', 'puppet']         $pki                    = 'puppet',
+  Optional[Stdlib::Absolutepath] $ssl_key_path           = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cert_path          = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cacert_path        = undef,
+  Optional[String]               $ssl_key                = undef,
+  Optional[String]               $ssl_cert               = undef,
+  Optional[String]               $ssl_cacert             = undef,
+  String                         $host_measurement       = '$host.check_command$',
+  Hash                           $host_tags              = { hostname => '$host.name$' },
+  String                         $service_measurement    = '$service.check_command$',
+  Hash                           $service_tags           = { hostname => '$host.name$', service => '$service.name$' },
+  Boolean                        $enable_send_thresholds = false,
+  Boolean                        $enable_send_metadata   = false,
+  Pattern[/^\d+[ms]*$/]          $flush_interval         = '10s',
+  Integer[1]                     $flush_threshold        = 1024
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -144,41 +144,19 @@ class icinga2::feature::influxdb(
     group   => $group,
   }
 
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($host)
-  validate_integer($port)
-  validate_string($database)
-  validate_string($username)
-  validate_string($password)
-  validate_bool($enable_ssl)
-  validate_re($pki, [ '^puppet$', '^none$' ],
-    "${pki} isn't supported. Valid values are 'puppet' and 'none'.")
-  validate_string($host_measurement)
-  validate_hash($host_tags)
-  validate_string($service_measurement)
-  validate_hash($service_tags)
-  validate_bool($enable_send_thresholds)
-  validate_bool($enable_send_metadata)
-  validate_re($flush_interval, '^\d+[ms]*$')
-  validate_integer($flush_threshold)
-
   $host_template = { measurement => $host_measurement, tags => $host_tags }
   $service_template = { measurement => $service_measurement, tags => $service_tags}
 
-  # Set defaults for certificate stuff and/or do validation
+  # Set defaults for certificate stuff
   if $ssl_key_path {
-    validate_absolute_path($ssl_key_path)
     $_ssl_key_path = $ssl_key_path }
   else {
     $_ssl_key_path = "${ssl_dir}/${node_name}.key" }
   if $ssl_cert_path {
-    validate_absolute_path($ssl_cert_path)
     $_ssl_cert_path = $ssl_cert_path }
   else {
     $_ssl_cert_path = "${ssl_dir}/${node_name}.crt" }
   if $ssl_cacert_path {
-    validate_absolute_path($ssl_cacert_path)
     $_ssl_cacert_path = $ssl_cacert_path }
   else {
     $_ssl_cacert_path = "${ssl_dir}/ca.crt" }

--- a/manifests/feature/livestatus.pp
+++ b/manifests/feature/livestatus.pp
@@ -31,12 +31,12 @@
 #
 #
 class icinga2::feature::livestatus(
-  $ensure          = present,
-  $socket_type     = 'unix',
-  $bind_host       = '127.0.0.1',
-  $bind_port       = '6558',
-  $socket_path     = "${::icinga2::params::run_dir}/cmd/livestatus",
-  $compat_log_path = "${::icinga2::params::log_dir}/compat",
+  Enum['absent', 'present'] $ensure          = present,
+  Enum['tcp', 'unix']       $socket_type     = 'unix',
+  String                    $bind_host       = '127.0.0.1',
+  Integer[1,65535]          $bind_port       = 6558,
+  Stdlib::Absolutepath      $socket_path     = "${::icinga2::params::run_dir}/cmd/livestatus",
+  Stdlib::Absolutepath      $compat_log_path = "${::icinga2::params::log_dir}/compat",
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -48,16 +48,6 @@ class icinga2::feature::livestatus(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_re($socket_type, [ '^unix$', '^tcp$' ],
-    "${socket_type} isn't supported. Valid values are 'unix' and 'tcp'.")
-  validate_string($bind_host)
-  validate_integer($bind_port)
-  validate_absolute_path($socket_path)
-  validate_absolute_path($compat_log_path)
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/mainlog.pp
+++ b/manifests/feature/mainlog.pp
@@ -16,9 +16,9 @@
 #
 #
 class icinga2::feature::mainlog(
-  $ensure   = present,
-  $severity = 'information',
-  $path     = "${::icinga2::params::log_dir}/icinga2.log",
+  Enum['absent', 'present']                         $ensure   = present,
+  Enum['debug', 'information', 'notice', 'warning'] $severity = 'information',
+  Stdlib::Absolutepath                              $path     = "${::icinga2::params::log_dir}/icinga2.log",
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -30,12 +30,6 @@ class icinga2::feature::mainlog(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_re($severity, ['^information$','^notice$','^warning$','^debug$'])
-  validate_absolute_path($path)
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/notification.pp
+++ b/manifests/feature/notification.pp
@@ -15,8 +15,8 @@
 #
 #
 class icinga2::feature::notification(
-  $ensure    = present,
-  $enable_ha = undef,
+  Enum['absent', 'present'] $ensure    = present,
+  Optional[Boolean]         $enable_ha = undef,
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -27,13 +27,6 @@ class icinga2::feature::notification(
   $_notify  = $ensure ? {
     'present' => Class['::icinga2::service'],
     default   => undef,
-  }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  if $enable_ha {
-    validate_bool($enable_ha)
   }
 
   # compose attributes

--- a/manifests/feature/opentsdb.pp
+++ b/manifests/feature/opentsdb.pp
@@ -15,9 +15,9 @@
 #
 #
 class icinga2::feature::opentsdb(
-  $ensure               = present,
-  $host                 = '127.0.0.1',
-  $port                 = '4242',
+  Enum['absent', 'present'] $ensure               = present,
+  String                    $host                 = '127.0.0.1',
+  Integer[1,65535]          $port                 = 4242,
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -29,12 +29,6 @@ class icinga2::feature::opentsdb(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($host)
-  validate_integer($port)
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/perfdata.pp
+++ b/manifests/feature/perfdata.pp
@@ -40,14 +40,14 @@
 #
 #
 class icinga2::feature::perfdata(
-  $ensure                  = present,
-  $host_perfdata_path      = "${::icinga2::params::spool_dir}/perfdata/host-perfdata",
-  $service_perfdata_path   = "${::icinga2::params::spool_dir}/perfdata/service-perfdata",
-  $host_temp_path          = "${::icinga2::params::spool_dir}/tmp/host-perfdata",
-  $service_temp_path       = "${::icinga2::params::spool_dir}/tmp/service-perfdata",
-  $host_format_template    = undef,
-  $service_format_template = undef,
-  $rotation_interval       = '30s',
+  Enum['absent', 'present'] $ensure                  = present,
+  Stdlib::Absolutepath      $host_perfdata_path      = "${::icinga2::params::spool_dir}/perfdata/host-perfdata",
+  Stdlib::Absolutepath      $service_perfdata_path   = "${::icinga2::params::spool_dir}/perfdata/service-perfdata",
+  Stdlib::Absolutepath      $host_temp_path          = "${::icinga2::params::spool_dir}/tmp/host-perfdata",
+  Stdlib::Absolutepath      $service_temp_path       = "${::icinga2::params::spool_dir}/tmp/service-perfdata",
+  Optional[String]          $host_format_template    = undef,
+  Optional[String]          $service_format_template = undef,
+  Pattern[/^\d+[ms]*$/]     $rotation_interval       = '30s',
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -59,20 +59,6 @@ class icinga2::feature::perfdata(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_absolute_path($host_perfdata_path)
-  validate_absolute_path($service_perfdata_path)
-  validate_absolute_path($host_temp_path)
-  validate_absolute_path($service_temp_path)
-  validate_re($rotation_interval, '^\d+[ms]*$')
-  if $host_format_template { validate_string($host_format_template) }
-  if $service_format_template { validate_string($service_format_template) }
-
-  if $host_format_template { validate_string($host_format_template) }
-  if $service_format_template { validate_string($service_format_template) }
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/statusdata.pp
+++ b/manifests/feature/statusdata.pp
@@ -23,10 +23,10 @@
 #
 #
 class icinga2::feature::statusdata(
-  $ensure          = present,
-  $status_path     = "${::icinga2::params::cache_dir}/status.dat",
-  $objects_path    = "${::icinga2::params::cache_dir}/objects.cache",
-  $update_interval = '15s',
+  Enum['absent', 'present'] $ensure          = present,
+  Stdlib::Absolutepath      $status_path     = "${::icinga2::params::cache_dir}/status.dat",
+  Stdlib::Absolutepath      $objects_path    = "${::icinga2::params::cache_dir}/objects.cache",
+  Pattern[/^\d+[ms]*$/]     $update_interval = '15s',
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -38,13 +38,6 @@ class icinga2::feature::statusdata(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_absolute_path($status_path)
-  validate_absolute_path($objects_path)
-  validate_re($update_interval, '^\d+[ms]*$')
 
   # compose attributes
   $attrs = {

--- a/manifests/feature/syslog.pp
+++ b/manifests/feature/syslog.pp
@@ -13,8 +13,8 @@
 #
 #
 class icinga2::feature::syslog(
-  $ensure   = present,
-  $severity = 'warning',
+  Enum['absent', 'present']                         $ensure   = present,
+  Enum['debug', 'information', 'notice', 'warning'] $severity = 'warning',
 ) {
 
   if ! defined(Class['::icinga2']) {
@@ -26,11 +26,6 @@ class icinga2::feature::syslog(
     'present' => Class['::icinga2::service'],
     default   => undef,
   }
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_re($severity, ['^information$','^notice$','^warning$','^debug$'])
 
   # compose attributes
   $attrs = {

--- a/manifests/object.pp
+++ b/manifests/object.pp
@@ -61,20 +61,20 @@
 #
 #
 define icinga2::object(
-  $object_type,
-  $target,
-  $order,
-  $ensure       = present,
-  $object_name  = $title,
-  $template     = false,
-  $apply        = false,
-  $attrs_list   = [],
-  $apply_target = undef,
-  $prefix       = false,
-  $import       = [],
-  $assign       = [],
-  $ignore       = [],
-  $attrs        = {},
+  String                                                   $object_type,
+  Stdlib::Absolutepath                                     $target,
+  String                                                   $order,
+  Enum['present', 'absent']                                $ensure       = present,
+  String                                                   $object_name  = $title,
+  Boolean                                                  $template     = false,
+  Variant[Boolean, Pattern[/^.+\s+(=>\s+.+\s+)?in\s+.+$/]] $apply        = false,
+  Array                                                    $attrs_list   = [],
+  Optional[Enum['Host', 'Service']]                        $apply_target = undef,
+  Boolean                                                  $prefix       = false,
+  Array                                                    $import       = [],
+  Array                                                    $assign       = [],
+  Array                                                    $ignore       = [],
+  Hash                                                     $attrs        = {},
 ) {
 
   assert_private()
@@ -97,23 +97,6 @@ define icinga2::object(
       }
     } # default
   }
-
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($object_name)
-  validate_bool($template)
-  unless is_bool($apply) { validate_re($apply, '^.+\s+(=>\s+.+\s+)?in\s+.+$') }
-  validate_bool($prefix)
-  if $apply_target { validate_re($apply_target, ['^Host$', '^Service$'],
-    "${apply_target} isn't supported. Valid values are 'Host' and 'Service'.") }
-  validate_array($import)
-  validate_array($assign)
-  validate_array($ignore)
-  validate_hash($attrs)
-  validate_string($object_type)
-  validate_absolute_path($target)
-  validate_string($order)
-  validate_array($attrs_list)
 
   if $object_type == $apply_target {
     fail('The object type must be different from the apply target')

--- a/manifests/object/apiuser.pp
+++ b/manifests/object/apiuser.pp
@@ -46,27 +46,14 @@
 #
 #
 define icinga2::object::apiuser(
-  $target,
-  $permissions,
-  $ensure       = present,
-  $apiuser_name = $title,
-  $password     = undef,
-  $client_cn    = undef,
-  $order        = '30',
+  Stdlib::Absolutepath      $target,
+  Array                     $permissions,
+  Enum['absent', 'present'] $ensure       = present,
+  String                    $apiuser_name = $title,
+  Optional[String]          $password     = undef,
+  Optional[String]          $client_cn    = undef,
+  Pattern[/^\d+$/]          $order        = '30',
 ) {
-
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_string($apiuser_name)
-  validate_string($order)
-  validate_absolute_path($target)
-  validate_array($permissions)
-
-  if $password { validate_string($password) }
-  if $client_cn { validate_string($client_cn) }
 
   # compose the attributes
   $attrs = {

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -40,36 +40,18 @@
 #
 #
 define icinga2::object::checkcommand(
-  $target,
-  $ensure            = present,
-  $checkcommand_name = $title,
-  $import            = ['plugin-check-command'],
-  $command           = undef,
-  $env               = undef,
-  $vars              = undef,
-  $timeout           = undef,
-  $arguments         = undef,
-  $template          = false,
-  $order             = '15',
+  Stdlib::Absolutepath             $target,
+  Enum['absent', 'present']        $ensure            = present,
+  Optional[String]                 $checkcommand_name = $title,
+  Array                            $import            = ['plugin-check-command'],
+  Optional[Variant[Array, String]] $command           = undef,
+  Optional[Hash]                   $env               = undef,
+  Optional[Hash]                   $vars              = undef,
+  Optional[Integer[1]]             $timeout           = undef,
+  Optional[Hash]                   $arguments         = undef,
+  Boolean                          $template          = false,
+  Pattern[/^\d+$/]                 $order             = '15',
 ) {
-
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_array($import)
-  validate_absolute_path($target)
-  validate_integer($order)
-
-  if $checkcommand_name { validate_string($checkcommand_name) }
-  if !is_array($command) { validate_string($command) }
-  if !is_string($command) { validate_array($command) }
-  if $env { validate_hash($env) }
-  if $timeout { validate_integer($timeout) }
-  if $arguments { validate_hash($arguments) }
 
   # compose the attributes
   $attrs = {

--- a/manifests/object/checkresultreader.pp
+++ b/manifests/object/checkresultreader.pp
@@ -22,24 +22,12 @@
 #
 #
 define icinga2::object::checkresultreader (
-  $target,
-  $ensure                 = present,
-  $checkresultreader_name = $title,
-  $spool_dir              = undef,
-  $order                  = '10',
+  Stdlib::Absolutepath           $target,
+  Enum['absent', 'present']      $ensure                 = present,
+  String                         $checkresultreader_name = $title,
+  Optional[Stdlib::Absolutepath] $spool_dir              = undef,
+  Pattern[/^\d+$/]               $order                  = '10',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($checkresultreader_name)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if $spool_dir { validate_absolute_path($spool_dir) }
 
   # compose the attributes
   $attrs = {

--- a/manifests/object/compatlogger.pp
+++ b/manifests/object/compatlogger.pp
@@ -22,29 +22,13 @@
 #
 #
 define icinga2::object::compatlogger (
-  $target,
-  $ensure            = present,
-  $compatlogger_name = $title,
-  $log_dir           = undef,
-  $rotation_method   = undef,
-  $order             = '5',
+  Stdlib::Absolutepath                                   $target,
+  Enum['absent', 'present']                              $ensure            = present,
+  String                                                 $compatlogger_name = $title,
+  Optional[Stdlib::Absolutepath]                         $log_dir           = undef,
+  Optional[Enum['DAILY', 'HOURLY', 'MONTHLY', 'WEEKLY']] $rotation_method   = undef,
+  Pattern[/^\d+$/]                                       $order             = '5',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($compatlogger_name)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if $log_dir { validate_absolute_path($log_dir) }
-  if $rotation_method {
-    validate_re($rotation_method, [ '^HOURLY$', '^DAILY$', '^WEEKLY$', '^MONTHLY$' ],
-      "${rotation_method} isn't supported. Valid values are 'HOURLY', 'DAILY', 'WEEKLY' and 'MONTHLY'.")
-  }
 
   # compose the attributes
   $attrs = {

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -74,53 +74,27 @@
 #
 #
 define icinga2::object::dependency (
-  $target,
-  $ensure                = present,
-  $dependency_name       = $title,
-  $parent_host_name      = undef,
-  $parent_service_name   = undef,
-  $child_host_name       = undef,
-  $child_service_name    = undef,
-  $disable_checks        = undef,
-  $disable_notifications = undef,
-  $ignore_soft_states    = undef,
-  $period                = undef,
-  $states                = undef,
-  $apply                 = false,
-  $prefix                = false,
-  $apply_target          = 'Host',
-  $assign                = [],
-  $ignore                = [],
-  $import                = [],
-  $template              = false,
-  $order                 = '70',
+  Stdlib::Absolutepath      $target,
+  Enum['absent', 'present'] $ensure                = present,
+  String                    $dependency_name       = $title,
+  Optional[String]          $parent_host_name      = undef,
+  Optional[String]          $parent_service_name   = undef,
+  Optional[String]          $child_host_name       = undef,
+  Optional[String]          $child_service_name    = undef,
+  Optional[Boolean]         $disable_checks        = undef,
+  Optional[Boolean]         $disable_notifications = undef,
+  Optional[Boolean]         $ignore_soft_states    = undef,
+  Optional[String]          $period                = undef,
+  Optional[Array]           $states                = undef,
+  Variant[Boolean, String]  $apply                 = false,
+  Boolean                   $prefix                = false,
+  Enum['Host', 'Service']   $apply_target          = 'Host',
+  Array                     $assign                = [],
+  Array                     $ignore                = [],
+  Array                     $import                = [],
+  Boolean                   $template              = false,
+  Pattern[/^\d+$/]          $order                 = '70',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($dependency_name)
-  unless is_bool($apply) { validate_string($apply) }
-  validate_bool($prefix)
-  validate_re($apply_target, ['^Host$', '^Service$'],
-    "${apply_target} isn't supported. Valid values are 'Host' and 'Service'.")
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if $parent_host_name { validate_string ($parent_host_name) }
-  if $parent_service_name { validate_string ( $parent_service_name ) }
-  if $child_host_name { validate_string ($child_host_name) }
-  if $child_service_name { validate_string ( $child_service_name ) }
-  if $disable_checks { validate_bool ( $disable_checks ) }
-  if $disable_notifications { validate_bool ( $disable_notifications ) }
-  if $ignore_soft_states { validate_bool ( $ignore_soft_states ) }
-  if $period { validate_string ( $period ) }
-  if $states { validate_array ( $states ) }
 
   # compose attributes
   $attrs = {

--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -31,34 +31,24 @@
 #
 #
 define icinga2::object::endpoint(
-  $ensure        = present,
-  $endpoint_name = $title,
-  $host          = undef,
-  $port          = undef,
-  $log_duration  = undef,
-  $target        = undef,
-  $order         = '40',
+  Enum['absent', 'present']                  $ensure        = present,
+  Optional[String]                           $endpoint_name = $title,
+  Optional[String]                           $host          = undef,
+  Optional[Integer[1,65535]]                 $port          = undef,
+  Optional[Pattern[/^\d+\.?\d*[d|h|m|s]?$/]] $log_duration  = undef,
+  Optional[Stdlib::Absolutepath]             $target        = undef,
+  Pattern[/^\d+$/]                           $order         = '40',
 ) {
 
   include ::icinga2::params
 
   $conf_dir = $::icinga2::params::conf_dir
 
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_integer($order)
-
-  if $endpoint_name { validate_string($endpoint_name) }
-  if $host { validate_string($host) }
-  if $port { validate_integer($port) }
-  if $log_duration { validate_re($log_duration, '^\d+\.?\d*[d|h|m|s]?$') }
-
   if $target {
-    validate_absolute_path($target)
-    $_target = $target }
-  else {
-    $_target = "${conf_dir}/zones.conf" }
+    $_target = $target
+  } else {
+    $_target = "${conf_dir}/zones.conf"
+  }
 
   # compose the attributes
   $attrs = {

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -44,34 +44,17 @@
 #
 #
 define icinga2::object::eventcommand (
-  $target,
-  $ensure            = present,
-  $eventcommand_name = $title,
-  $command           = undef,
-  $env               = undef,
-  $vars              = undef,
-  $timeout           = undef,
-  $arguments         = undef,
-  $import            = ['plugin-event-command'],
-  $order             = '20',
+  Stdlib::Absolutepath            $target,
+  Enum['absent', 'present']       $ensure            = present,
+  String                          $eventcommand_name = $title,
+  Optional[Variant[Array,String]] $command           = undef,
+  Optional[Hash]                  $env               = undef,
+  Optional[Hash]                  $vars              = undef,
+  Optional[Integer[1]]            $timeout           = undef,
+  Optional[Hash]                  $arguments         = undef,
+  Array                           $import            = ['plugin-event-command'],
+  Pattern[/^\d+$/]                $order             = '20',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($eventcommand_name)
-  validate_absolute_path($target)
-  validate_string($order)
-  validate_array($import)
-
-  if !is_array($command) { validate_string($command) }
-  if !is_string($command) { validate_array($command) }
-  if $env { validate_hash($env) }
-  if $timeout { validate_integer($timeout) }
-  if $arguments { validate_hash($arguments) }
 
   # compose the attributes
   $attrs = {

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -108,80 +108,40 @@
 #
 #
 define icinga2::object::host(
-  $target,
-  $ensure                = present,
-  $host_name             = $title,
-  $import                = [],
-  $address               = undef,
-  $address6              = undef,
-  $vars                  = undef,
-  $groups                = undef,
-  $display_name          = undef,
-  $check_command         = undef,
-  $max_check_attempts    = undef,
-  $check_period          = undef,
-  $check_timeout         = undef,
-  $check_interval        = undef,
-  $retry_interval        = undef,
-  $enable_notifications  = undef,
-  $enable_active_checks  = undef,
-  $enable_passive_checks = undef,
-  $enable_event_handler  = undef,
-  $enable_flapping       = undef,
-  $enable_perfdata       = undef,
-  $event_command         = undef,
-  $flapping_threshold    = undef,
-  $volatile              = undef,
-  $zone                  = undef,
-  $command_endpoint      = undef,
-  $notes                 = undef,
-  $notes_url             = undef,
-  $action_url            = undef,
-  $icon_image            = undef,
-  $icon_image_alt        = undef,
-  $template              = false,
-  $order                 = '50',
+  Stdlib::Absolutepath                       $target,
+  Enum['absent', 'present']                  $ensure                = present,
+  Optional[String]                           $host_name             = $title,
+  Array                                      $import                = [],
+  Optional[String]                           $address               = undef,
+  Optional[String]                           $address6              = undef,
+  Optional[Hash]                             $vars                  = undef,
+  Optional[Array]                            $groups                = undef,
+  Optional[String]                           $display_name          = undef,
+  Optional[String]                           $check_command         = undef,
+  Optional[Integer[1]]                       $max_check_attempts    = undef,
+  Optional[String]                           $check_period          = undef,
+  Optional[Pattern[/^\d+\.?\d*[d|h|m|s]?$/]] $check_timeout         = undef,
+  Optional[Pattern[/^\d+\.?\d*[d|h|m|s]?$/]] $check_interval        = undef,
+  Optional[Pattern[/^\d+\.?\d*[d|h|m|s]?$/]] $retry_interval        = undef,
+  Optional[Boolean]                          $enable_notifications  = undef,
+  Optional[Boolean]                          $enable_active_checks  = undef,
+  Optional[Boolean]                          $enable_passive_checks = undef,
+  Optional[Boolean]                          $enable_event_handler  = undef,
+  Optional[Boolean]                          $enable_flapping       = undef,
+  Optional[Boolean]                          $enable_perfdata       = undef,
+  Optional[String]                           $event_command         = undef,
+  Optional[Integer[1]]                       $flapping_threshold    = undef,
+  Optional[Boolean]                          $volatile              = undef,
+  Optional[String]                           $zone                  = undef,
+  Optional[String]                           $command_endpoint      = undef,
+  Optional[String]                           $notes                 = undef,
+  Optional[String]                           $notes_url             = undef,
+  Optional[String]                           $action_url            = undef,
+  Optional[Stdlib::Absolutepath]             $icon_image            = undef,
+  Optional[String]                           $icon_image_alt        = undef,
+  Boolean                                    $template              = false,
+  Pattern[/^\d+$/]                           $order                 = '50',
 ) {
-
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_integer($order)
-
-  if $host_name { validate_string($host_name) }
-  if $address { validate_string($address) }
-  if $address6 { validate_string($address6) }
-  if $groups { validate_array($groups) }
-  if $display_name { validate_string($display_name) }
-  if $check_command { validate_string($check_command) }
-  if $max_check_attempts { validate_integer($max_check_attempts) }
-  if $check_period { validate_string($check_period) }
-  if $check_timeout { validate_re($check_timeout, '^\d+\.?\d*[d|h|m|s]?$') }
-  if $check_interval { validate_re($check_interval, '^\d+\.?\d*[d|h|m|s]?$') }
-  if $retry_interval { validate_re($retry_interval, '^\d+\.?\d*[d|h|m|s]?$') }
-  if $enable_notifications { validate_bool($enable_notifications) }
-  if $enable_active_checks { validate_bool($enable_active_checks) }
-  if $enable_passive_checks { validate_bool($enable_passive_checks) }
-  if $enable_event_handler { validate_bool($enable_event_handler) }
-  if $enable_flapping { validate_bool($enable_flapping) }
-  if $enable_perfdata { validate_bool($enable_perfdata) }
-  if $event_command { validate_string($event_command) }
-  if $flapping_threshold { validate_integer($flapping_threshold) }
-  if $volatile { validate_bool($volatile) }
-  if $zone { validate_string($zone) }
-  if $command_endpoint { validate_string($command_endpoint) }
-  if $notes { validate_string($notes) }
-  if $notes_url { validate_string($notes_url) }
-  if $action_url { validate_string($action_url) }
-  if $icon_image { validate_absolute_path($icon_image) }
-  if $icon_image_alt { validate_string($icon_image_alt) }
 
   # compose the attributes
   $attrs = {

--- a/manifests/object/hostgroup.pp
+++ b/manifests/object/hostgroup.pp
@@ -34,27 +34,15 @@
 #
 #
 define icinga2::object::hostgroup(
-  $target,
-  $ensure         = present,
-  $hostgroup_name = $title,
-  $display_name   = undef,
-  $groups         = undef,
-  $assign         = [],
-  $ignore         = [],
-  $order          = '55',
+  Stdlib::Absolutepath      $target,
+  Enum['absent', 'present'] $ensure         = present,
+  String                    $hostgroup_name = $title,
+  Optional[String]          $display_name   = undef,
+  Optional[Array]           $groups         = undef,
+  Array                     $assign         = [],
+  Array                     $ignore         = [],
+  Pattern[/^\d+$/]          $order          = '55',
 ) {
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($hostgroup_name)
-  validate_array($assign)
-  validate_array($ignore)
-  validate_string($order)
-  validate_absolute_path($target)
-
-  if $display_name { validate_string($display_name) }
-  if $groups { validate_array($groups) }
 
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -79,64 +79,30 @@
 #
 #
 define icinga2::object::notification (
-  $target,
-  $ensure            = present,
-  $notification_name = $title,
-  $host_name         = undef,
-  $service_name      = undef,
-  $vars              = undef,
-  $users             = undef,
-  $user_groups       = undef,
-  $times             = undef,
-  $command           = undef,
-  $interval          = undef,
-  $period            = undef,
-  $zone              = undef,
-  $types             = undef,
-  $states            = undef,
-  $apply             = false,
-  $prefix            = false,
-  $apply_target      = 'Host',
-  $assign            = [],
-  $ignore            = [],
-  $import            = [],
-  $template          = false,
-  $order             = '85',
+  Stdlib::Absolutepath                       $target,
+  Enum['absent', 'present']                  $ensure            = present,
+  String                                     $notification_name = $title,
+  Optional[String]                           $host_name         = undef,
+  Optional[String]                           $service_name      = undef,
+  Optional[Hash]                             $vars              = undef,
+  Optional[Variant[Array, String]]           $users             = undef,
+  Optional[Variant[Array, String]]           $user_groups       = undef,
+  Optional[Hash]                             $times             = undef,
+  Optional[String]                           $command           = undef,
+  Optional[Pattern[/^\d+\.?\d*[d|h|m|s]?$/]] $interval          = undef,
+  Optional[String]                           $period            = undef,
+  Optional[String]                           $zone              = undef,
+  Optional[Variant[Array, String]]           $types             = undef,
+  Optional[Variant[Array, String]]           $states            = undef,
+  Variant[Boolean, String]                   $apply             = false,
+  Boolean                                    $prefix            = false,
+  Enum['Host', 'Service']                    $apply_target      = 'Host',
+  Array                                      $assign            = [],
+  Array                                      $ignore            = [],
+  Array                                      $import            = [],
+  Boolean                                    $template          = false,
+  Pattern[/^\d+$/]                           $order             = '85',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($notification_name)
-  unless is_bool($apply) { validate_string($apply) }
-  validate_bool($prefix)
-  validate_re($apply_target, ['^Host$', '^Service$'],
-    "${apply_target} isn't supported. Valid values are 'Host' and 'Service'.")
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  validate_string ($host_name)
-  if $service_name { validate_string ($service_name)}
-  if !is_array($users) { validate_string($users) }
-  if !is_string($users) { validate_array($users) }
-  if !is_array($user_groups) { validate_string($user_groups) }
-  if !is_string($user_groups) { validate_array($user_groups) }
-  if $times { validate_hash ($times )}
-  if $command { validate_string ($command )}
-  if $interval { validate_re($interval, '^\d+(\.\d+)?[dhms]?$')}
-  if $period { validate_string ($period )}
-  if $zone { validate_string ($zone) }
-  if !is_array($types) { validate_string($types) }
-  if !is_string($types) { validate_array($types) }
-  if !is_array($states) { validate_string($states) }
-  if !is_string($states) { validate_array($states) }
-  if $assign { validate_array ($assign) }
-  if $ignore { validate_array ($ignore) }
 
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')
@@ -144,18 +110,18 @@ define icinga2::object::notification (
 
   # compose attributes
   $attrs = {
-    'host_name' => $host_name,
+    'host_name'    => $host_name,
     'service_name' => $service_name,
-    'users' => $users,
-    'user_groups' => $user_groups,
-    'times' => $times,
-    'command' => $command,
-    'interval' => $interval,
-    'period' => $period,
-    'zone' => $zone,
-    'types' => $types,
-    'states' => $states,
-    'vars' => $vars,
+    'users'        => $users,
+    'user_groups'  => $user_groups,
+    'times'        => $times,
+    'command'      => $command,
+    'interval'     => $interval,
+    'period'       => $period,
+    'zone'         => $zone,
+    'types'        => $types,
+    'states'       => $states,
+    'vars'         => $vars,
   }
 
   # create object

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -49,36 +49,18 @@
 #
 #
 define icinga2::object::notificationcommand (
-  $target,
-  $ensure                   = present,
-  $notificationcommand_name = $title,
-  $command                  = undef,
-  $env                      = undef,
-  $vars                     = undef,
-  $timeout                  = undef,
-  $arguments                = undef,
-  $template                 = false,
-  $import                   = ['plugin-notification-command'],
-  $order                    = '25',
+  Stdlib::Absolutepath             $target,
+  Enum['absent', 'present']        $ensure                   = present,
+  String                           $notificationcommand_name = $title,
+  Optional[Variant[Array, String]] $command                  = undef,
+  Optional[Hash]                   $env                      = undef,
+  Optional[Hash]                   $vars                     = undef,
+  Optional[Integer[1]]             $timeout                  = undef,
+  Optional[Hash]                   $arguments                = undef,
+  Boolean                          $template                 = false,
+  Array                            $import                   = ['plugin-notification-command'],
+  Pattern[/^\d+$/]                 $order                    = '25',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($notificationcommand_name)
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if !is_array($command) { validate_string($command) }
-  if !is_string($command) { validate_array($command) }
-  if $env { validate_hash ($env) }
-  if $timeout { validate_integer ($timeout) }
-  if $arguments { validate_hash ($arguments) }
 
   # compose attributes
   $attrs = {

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -56,45 +56,23 @@
 #
 #
 define icinga2::object::scheduleddowntime (
-  $target,
-  $ensure                 = present,
-  $scheduleddowntime_name = $title,
-  $host_name              = undef,
-  $service_name           = undef,
-  $author                 = undef,
-  $comment                = undef,
-  $fixed                  = undef,
-  $duration               = undef,
-  $ranges                 = undef,
-  $apply                  = false,
-  $prefix                 = false,
-  $apply_target           = 'Host',
-  $assign                 = [],
-  $ignore                 = [],
-  $order                  = '90',
+  Stdlib::Absolutepath                      $target,
+  Enum['absent', 'present']                 $ensure                 = present,
+  String                                    $scheduleddowntime_name = $title,
+  Optional[String]                          $host_name              = undef,
+  Optional[String]                          $service_name           = undef,
+  Optional[String]                          $author                 = undef,
+  Optional[String]                          $comment                = undef,
+  Optional[Boolean]                         $fixed                  = undef,
+  Optional[Pattern[/^\d+(\.\d+)?[dhms]?$/]] $duration               = undef,
+  Optional[Hash]                            $ranges                 = undef,
+  Variant[Boolean, String]                  $apply                  = false,
+  Boolean                                   $prefix                 = false,
+  Enum['Host', 'Service']                   $apply_target           = 'Host',
+  Array                                     $assign                 = [],
+  Array                                     $ignore                 = [],
+  Pattern[/^\d+$/]                          $order                  = '90',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($scheduleddowntime_name)
-  unless is_bool($apply) { validate_string($apply) }
-  validate_bool($prefix)
-  validate_re($apply_target, ['^Host$', '^Service$'],
-    "${apply_target} isn't supported. Valid values are 'Host' and 'Service'.")
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if $host_name { validate_string($host_name) }
-  if $service_name { validate_string ($service_name) }
-  if $author { validate_string($author) }
-  if $comment { validate_string($comment) }
-  if $fixed { validate_bool($fixed) }
-  if $duration { validate_re($duration, '^\d+(\.\d+)?[dhms]?$') }
-  if $ranges { validate_hash($ranges) }
 
   # compose attributes
   $attrs = {

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -158,85 +158,43 @@
 #
 
 define icinga2::object::service (
-  $target,
-  $ensure                 = present,
-  $service_name           = $title,
-  $display_name           = undef,
-  $host_name              = undef,
-  $groups                 = undef,
-  $vars                   = undef,
-  $check_command          = undef,
-  $max_check_attempts     = undef,
-  $check_period           = undef,
-  $check_timeout          = undef,
-  $check_interval         = undef,
-  $retry_interval         = undef,
-  $enable_notifications   = undef,
-  $enable_active_checks   = undef,
-  $enable_passive_checks  = undef,
-  $enable_event_handler   = undef,
-  $enable_flapping        = undef,
-  $enable_perfdata        = undef,
-  $event_command          = undef,
-  $flapping_threshold     = undef,
-  $volatile               = undef,
-  $zone                   = undef,
-  $command_endpoint       = undef,
-  $notes                  = undef,
-  $notes_url              = undef,
-  $action_url             = undef,
-  $icon_image             = undef,
-  $icon_image_alt         = undef,
-  $apply                  = false,
-  $prefix                 = false,
-  $assign                 = [],
-  $ignore                 = [],
-  $import                 = [],
-  $template               = false,
-  $order                  = '60',
+  Stdlib::Absolutepath                       $target,
+  Enum['absent', 'present']                  $ensure                 = present,
+  String                                     $service_name           = $title,
+  Optional[String]                           $display_name           = undef,
+  Optional[String]                           $host_name              = undef,
+  Optional[Array]                            $groups                 = undef,
+  Optional[Hash]                             $vars                   = undef,
+  Optional[String]                           $check_command          = undef,
+  Optional[Integer[1]]                       $max_check_attempts     = undef,
+  Optional[String]                           $check_period           = undef,
+  Optional[Pattern[/^\d+\.?\d*[d|h|m|s]?$/]] $check_timeout          = undef,
+  Optional[Pattern[/^\d+\.?\d*[d|h|m|s]?$/]] $check_interval         = undef,
+  Optional[Pattern[/^\d+\.?\d*[d|h|m|s]?$/]] $retry_interval         = undef,
+  Optional[Boolean]                          $enable_notifications   = undef,
+  Optional[Boolean]                          $enable_active_checks   = undef,
+  Optional[Boolean]                          $enable_passive_checks  = undef,
+  Optional[Boolean]                          $enable_event_handler   = undef,
+  Optional[Boolean]                          $enable_flapping        = undef,
+  Optional[Boolean]                          $enable_perfdata        = undef,
+  Optional[String]                           $event_command          = undef,
+  Optional[Integer[1]]                       $flapping_threshold     = undef,
+  Optional[Boolean]                          $volatile               = undef,
+  Optional[String]                           $zone                   = undef,
+  Optional[String]                           $command_endpoint       = undef,
+  Optional[String]                           $notes                  = undef,
+  Optional[String]                           $notes_url              = undef,
+  Optional[String]                           $action_url             = undef,
+  Optional[Stdlib::Absolutepath]             $icon_image             = undef,
+  Optional[String]                           $icon_image_alt         = undef,
+  Variant[Boolean, String]                   $apply                  = false,
+  Boolean                                    $prefix                 = false,
+  Array                                      $assign                 = [],
+  Array                                      $ignore                 = [],
+  Array                                      $import                 = [],
+  Boolean                                    $template               = false,
+  Pattern[/^\d+$/]                           $order                  = '60',
 ) {
-
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($service_name)
-  unless is_bool($apply) { validate_string($apply) }
-  validate_bool($prefix)
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if $display_name { validate_string ($display_name) }
-  if $host_name { validate_string($host_name) }
-  if $groups { validate_array ($groups) }
-  if $check_command { validate_string($check_command) }
-  if $max_check_attempts { validate_integer ($max_check_attempts) }
-  if $check_period { validate_string ($check_period) }
-  if $check_timeout { validate_re($check_timeout, '^\d+\.?\d*[d|h|m|s]?$') }
-  if $check_interval { validate_re($check_interval, '^\d+\.?\d*[d|h|m|s]?$') }
-  if $retry_interval { validate_re($retry_interval, '^\d+\.?\d*[d|h|m|s]?$') }
-  if $enable_notifications { validate_bool ($enable_notifications) }
-  if $enable_active_checks { validate_bool ($enable_active_checks) }
-  if $enable_passive_checks { validate_bool ($enable_passive_checks) }
-  if $enable_event_handler { validate_bool ($enable_event_handler) }
-  if $enable_flapping { validate_bool ($enable_flapping) }
-  if $enable_perfdata { validate_bool ($enable_perfdata) }
-  if $event_command { validate_string ($event_command) }
-  if $flapping_threshold { validate_integer ($flapping_threshold) }
-  if $volatile { validate_bool ($volatile) }
-  if $zone { validate_string ($zone) }
-  if $command_endpoint { validate_string ($command_endpoint) }
-  if $notes { validate_string ($notes) }
-  if $notes_url { validate_string ($notes_url) }
-  if $action_url { validate_string ($action_url) }
-  if $icon_image { validate_absolute_path ($icon_image) }
-  if $icon_image_alt { validate_string ($icon_image_alt) }
-
 
   # compose the attributes
   $attrs = {

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -37,33 +37,17 @@
 #
 #
 define icinga2::object::servicegroup (
-  $target,
-  $ensure            = present,
-  $servicegroup_name = $title,
-  $display_name      = undef,
-  $groups            = undef,
-  $assign            = [],
-  $ignore            = [],
-  $template          = false,
-  $import            = [],
-  $order             = '65',
+  Stdlib::Absolutepath      $target,
+  Enum['absent', 'present'] $ensure            = present,
+  String                    $servicegroup_name = $title,
+  Optional[String]          $display_name      = undef,
+  Optional[Array]           $groups            = undef,
+  Array                     $assign            = [],
+  Array                     $ignore            = [],
+  Boolean                   $template          = false,
+  Array                     $import            = [],
+  Pattern[/^\d+$/]          $order             = '65',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($servicegroup_name)
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if $display_name { validate_string ( $display_name ) }
-  if $groups { validate_array ( $groups ) }
-
 
   # compose attributes
   $attrs = {

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -40,37 +40,18 @@
 #
 #
 define icinga2::object::timeperiod (
-  $target,
-  $ensure          = present,
-  $timeperiod_name = $title,
-  $display_name    = undef,
-  $ranges          = undef,
-  $prefer_includes = undef,
-  $excludes        = undef,
-  $includes        = undef,
-  $template        = false,
-  $import          = ['legacy-timeperiod'],
-  $order           = '35',
+  Stdlib::Absolutepath      $target,
+  Enum['absent', 'present'] $ensure          = present,
+  String                    $timeperiod_name = $title,
+  Optional[String]          $display_name    = undef,
+  Optional[Hash]            $ranges          = undef,
+  Optional[Boolean]         $prefer_includes = undef,
+  Optional[Array]           $excludes        = undef,
+  Optional[Array]           $includes        = undef,
+  Boolean                   $template        = false,
+  Array                     $import          = ['legacy-timeperiod'],
+  Pattern[/^\d+$/]          $order           = '35',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($timeperiod_name)
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_string($order)
-
-
-  if $display_name { validate_string ($display_name) }
-  if $ranges { validate_hash ($ranges) }
-  if $prefer_includes { validate_bool ($prefer_includes) }
-  if $excludes { validate_array ($excludes) }
-  if $includes { validate_array ($includes) }
 
   # compose attributes
   $attrs = {

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -56,45 +56,22 @@
 #
 #
 define icinga2::object::user (
-  $target,
-  $ensure               = present,
-  $user_name            = $title,
-  $display_name         = undef,
-  $email                = undef,
-  $pager                = undef,
-  $vars                 = undef,
-  $groups               = undef,
-  $enable_notifications = undef,
-  $period               = undef,
-  $types                = undef,
-  $states               = undef,
-  $import               = [],
-  $template             = false,
-  $order                = '75',
+  Stdlib::Absolutepath      $target,
+  Enum['absent', 'present'] $ensure               = present,
+  String                    $user_name            = $title,
+  Optional[String]          $display_name         = undef,
+  Optional[String]          $email                = undef,
+  Optional[String]          $pager                = undef,
+  Optional[Hash]            $vars                 = undef,
+  Optional[Array]           $groups               = undef,
+  Optional[Boolean]         $enable_notifications = undef,
+  Optional[String]          $period               = undef,
+  Optional[Array]           $types                = undef,
+  Optional[Array]           $states               = undef,
+  Array                     $import               = [],
+  Boolean                   $template             = false,
+  Pattern[/^\d+$/]          $order                = '75',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($user_name)
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if $display_name { validate_string ($display_name) }
-  if $email { validate_string ($email) }
-  if $pager { validate_string ($pager) }
-  if $groups { validate_array ($groups) }
-  if $enable_notifications { validate_bool ($enable_notifications) }
-  if $period { validate_string ($period) }
-  if $types { validate_array ($types) }
-  if $states { validate_array ($states) }
-
-  validate_integer ( $order )
 
   # compose attributes
   $attrs = {

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -37,32 +37,17 @@
 #
 #
 define icinga2::object::usergroup (
-  $target,
-  $ensure         = present,
-  $usergroup_name = $title,
-  $display_name   = undef,
-  $groups         = [],
-  $assign         = [],
-  $ignore         = [],
-  $import         = [],
-  $template       = false,
-  $order          = '80',
+  Stdlib::Absolutepath      $target,
+  Enum['absent', 'present'] $ensure         = present,
+  String                    $usergroup_name = $title,
+  Optional[String]          $display_name   = undef,
+  Array                     $groups         = [],
+  Array                     $assign         = [],
+  Array                     $ignore         = [],
+  Array                     $import         = [],
+  Boolean                   $template       = false,
+  Pattern[/^\d+$/]          $order          = '80',
 ){
-  include ::icinga2::params
-
-  $conf_dir = $::icinga2::params::conf_dir
-
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($usergroup_name)
-  validate_array($import)
-  validate_bool($template)
-  validate_absolute_path($target)
-  validate_string($order)
-
-  if $display_name { validate_string ($display_name) }
-  if $groups { validate_array ($groups) }
 
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')

--- a/manifests/object/zone.pp
+++ b/manifests/object/zone.pp
@@ -29,37 +29,25 @@
 #
 #
 define icinga2::object::zone(
-  $ensure    = present,
-  $zone_name = $title,
-  $endpoints = [],
-  $parent    = undef,
-  $global    = false,
-  $target    = undef,
-  $order     = '45',
+  Enum['absent', 'present']      $ensure    = present,
+  String                         $zone_name = $title,
+  Optional[Array]                $endpoints = [],
+  Optional[String]               $parent    = undef,
+  Optional[Boolean]              $global    = false,
+  Optional[Stdlib::Absolutepath] $target    = undef,
+  Pattern[/^\d+$/]               $order     = '45',
 ) {
 
   include ::icinga2::params
 
   $conf_dir = $::icinga2::params::conf_dir
 
-  # validation
-  validate_re($ensure, [ '^present$', '^absent$' ],
-    "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
-  validate_string($zone_name)
-  validate_integer($order)
-
-  if $endpoints { validate_array($endpoints) }
-  if $parent { validate_string($parent) }
-  if $global { validate_bool($global) }
-
-  # set defaults and validate
+  # set defaults
   if $target {
-    validate_absolute_path($target)
-    $_target = $target }
-  else {
-    $_target = "${conf_dir}/zones.conf" }
-
-  validate_string($order)
+    $_target = $target
+  } else {
+    $_target = "${conf_dir}/zones.conf"
+  }
 
   # compose the attributes
   if $global {

--- a/manifests/pki/ca.pp
+++ b/manifests/pki/ca.pp
@@ -53,12 +53,12 @@
 #
 #
 class icinga2::pki::ca(
-  $ca_cert         = undef,
-  $ca_key          = undef,
-  $ssl_key_path    = undef,
-  $ssl_cert_path   = undef,
-  $ssl_csr_path    = undef,
-  $ssl_cacert_path = undef,
+  Optional[String]               $ca_cert         = undef,
+  Optional[String]               $ca_key          = undef,
+  Optional[Stdlib::Absolutepath] $ssl_key_path    = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cert_path   = undef,
+  Optional[Stdlib::Absolutepath] $ssl_csr_path    = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cacert_path = undef,
 ) {
 
   include ::icinga2::params
@@ -81,22 +81,18 @@ class icinga2::pki::ca(
   }
 
   if $ssl_key_path {
-    validate_absolute_path($ssl_key_path)
     $_ssl_key_path = $ssl_key_path }
   else {
     $_ssl_key_path = "${pki_dir}/${node_name}.key" }
   if $ssl_cert_path {
-    validate_absolute_path($ssl_cert_path)
     $_ssl_cert_path = $ssl_cert_path }
   else {
     $_ssl_cert_path = "${pki_dir}/${node_name}.crt" }
   if $ssl_csr_path {
-    validate_absolute_path($ssl_csr_path)
     $_ssl_csr_path = $ssl_csr_path }
   else {
     $_ssl_csr_path = "${pki_dir}/${node_name}.csr" }
   if $ssl_cacert_path {
-    validate_absolute_path($ssl_cacert_path)
     $_ssl_cacert_path = $ssl_cacert_path }
   else {
     $_ssl_cacert_path = "${pki_dir}/ca.crt" }
@@ -114,9 +110,6 @@ class icinga2::pki::ca(
       notify  => Class['::icinga2::service'],
     }
   } else {
-    validate_string($ca_cert)
-    validate_string($ca_key)
-
     if $::osfamily == 'windows' {
       $_ca_dir_mode = undef
       $_ca_cert      = regsubst($ca_cert, '\n', "\r\n", 'EMG')
@@ -157,7 +150,7 @@ class icinga2::pki::ca(
   exec { 'icinga2 pki create certificate signing request':
     command => "icinga2 pki new-cert --cn '${node_name}' --key '${_ssl_key_path}' --csr '${_ssl_csr_path}'",
     creates => $_ssl_key_path,
-    require => File[$_ssl_cacert_path]
+    require => File[$_ssl_cacert_path],
   }
 
   -> file { $_ssl_key_path:

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -23,7 +23,7 @@ class icinga2::repo {
     case $::osfamily {
       'redhat': {
         case $::operatingsystem {
-          'centos', 'redhat', 'oraclelinux', 'cloudlinux': {
+          'centos', 'redhat', 'oraclelinux', 'cloudlinux', 'xenserver': {
             yumrepo { 'icinga-stable-release':
               baseurl  => "http://packages.icinga.com/epel/${::operatingsystemmajrelease}/release/",
               descr    => 'ICINGA (stable release for epel)',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -23,7 +23,7 @@ class icinga2::repo {
     case $::osfamily {
       'redhat': {
         case $::operatingsystem {
-          'centos', 'redhat', 'oraclelinux': {
+          'centos', 'redhat', 'oraclelinux', 'cloudlinux': {
             yumrepo { 'icinga-stable-release':
               baseurl  => "http://packages.icinga.com/epel/${::operatingsystemmajrelease}/release/",
               descr    => 'ICINGA (stable release for epel)',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -76,7 +76,7 @@ class icinga2::repo {
       'suse': {
 
         file { '/etc/pki/GPG-KEY-icinga':
-          ensure => present,
+          ensure => file,
           source => 'http://packages.icinga.com/icinga.key',
         }
 
@@ -94,7 +94,7 @@ class icinga2::repo {
               baseurl  => "http://packages.icinga.com/SUSE/${::operatingsystemrelease}/release/",
               enabled  => 1,
               gpgcheck => 1,
-              require  => Exec['import icinga gpg key']
+              require  => Exec['import icinga gpg key'],
             }
           }
           default: {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "icinga-icinga2",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": "Icinga Development Team",
   "summary": "Icinga 2 Puppet Module",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.16.0 < 5.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.1 < 5.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">= 2.1.0 < 5.0.0" }
   ],
   "operatingsystem_support": [
     {

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -87,7 +87,7 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with pki => foo (not a valid value)" do
       let(:params) { {:pki => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['ca', 'icinga2', 'none', 'puppet'\]/) }
     end
 
 
@@ -118,7 +118,8 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with ssl_key_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:ssl_key_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -134,7 +135,7 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with ssl_cert_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:ssl_cert_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -150,7 +151,7 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with ssl_cacert_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:ssl_cacert_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -175,7 +176,7 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with accept_config => foo (not a valid boolean)" do
       let(:params) { {:accept_config => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
 
@@ -200,7 +201,7 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with accept_commands => foo (not a valid boolean)" do
       let(:params) { {:accept_commands => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
 
@@ -213,7 +214,7 @@ describe('icinga2::feature::api', :type => :class) do
 
 
     context "#{os} with pki => 'icinga2', ca_port => 1234" do
-      let(:params) { {:pki => 'icinga2',:ca_port => '1234'} }
+      let(:params) { {:pki => 'icinga2',:ca_port => 1234} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::ApiListener::api')
                               .with({ 'target' => '/etc/icinga2/features-available/api.conf' }) }
@@ -223,7 +224,7 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with pki => 'icinga2', ca_port => foo (not a valid integer)" do
       let(:params) { {:pki => 'icinga2',:ca_port => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
 
 
@@ -246,7 +247,7 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with endpoints => foo (not a valid hash)" do
       let(:params) { {:endpoints => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
     end
 
 
@@ -261,7 +262,7 @@ describe('icinga2::feature::api', :type => :class) do
     context "#{os} with zones => foo (not a valid hash)" do
       let(:params) { {:zones => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
     end
 
     context "#{os} with TLS detail settings" do
@@ -380,7 +381,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with pki => foo (not a valid value)" do
     let(:params) { {:pki => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['ca', 'icinga2', 'none', 'puppet'\]/) }
   end
 
 
@@ -410,7 +411,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with ssl_key_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:ssl_key_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -426,7 +427,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with ssl_cert_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:ssl_cert_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -442,7 +443,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with ssl_cacert_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:ssl_cacert_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -467,7 +468,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with accept_config => foo (not a valid boolean)" do
     let(:params) { {:accept_config => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
 
@@ -492,7 +493,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with accept_config => foo (not a valid boolean)" do
     let(:params) { {:accept_commands => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
 
@@ -514,7 +515,7 @@ describe('icinga2::feature::api', :type => :class) do
 
 
   context "Windows 2012 R2 with pki => 'icinga2', ca_port => 1234" do
-    let(:params) { {:pki => 'icinga2',:ca_port => '1234'} }
+    let(:params) { {:pki => 'icinga2',:ca_port => 1234} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::ApiListener::api')
                             .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/api.conf' }) }
@@ -524,7 +525,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with pki => 'icinga2', ca_port => foo (not a valid integer)" do
     let(:params) { {:pki => 'icinga2',:ca_port => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
   end
 
 
@@ -538,7 +539,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with endpoints => foo (not a valid hash)" do
     let(:params) { {:endpoints => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
   end
 
 
@@ -553,7 +554,7 @@ describe('icinga2::feature::api', :type => :class) do
   context "Windows 2012 R2 with zones => foo (not a valid hash)" do
     let(:params) { {:zones => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
   end
 
   context 'Windows 2012 R2 with bind settings' do

--- a/spec/classes/ca_spec.rb
+++ b/spec/classes/ca_spec.rb
@@ -41,7 +41,7 @@ describe('icinga2::pki::ca', :type => :class) do
     context "#{os} with ssl_key_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:ssl_key_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -55,7 +55,7 @@ describe('icinga2::pki::ca', :type => :class) do
     context "#{os} with ssl_cert_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:ssl_cert_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -69,7 +69,7 @@ describe('icinga2::pki::ca', :type => :class) do
     context "#{os} with ssl_csr_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:ssl_csr_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -83,7 +83,7 @@ describe('icinga2::pki::ca', :type => :class) do
     context "#{os} with ssl_cacert_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:ssl_cacert_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
   end
 end
@@ -142,7 +142,7 @@ describe('icinga2::pki::ca', :type => :class) do
   context "Windows 2012 R2 with ssl_key_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:ssl_key_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -156,7 +156,7 @@ describe('icinga2::pki::ca', :type => :class) do
   context "Windows 2012 R2 with ssl_cert_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:ssl_cert_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -170,7 +170,7 @@ describe('icinga2::pki::ca', :type => :class) do
   context "Windows 2012 R2 with ssl_csr_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:ssl_csr_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -184,7 +184,7 @@ describe('icinga2::pki::ca', :type => :class) do
   context "Windows 2012 R2 with ssl_cacert_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:ssl_cacert_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 

--- a/spec/classes/checker_spec.rb
+++ b/spec/classes/checker_spec.rb
@@ -43,7 +43,7 @@ describe('icinga2::feature::checker', :type => :class) do
     context "#{os} with concurrent_checks => foo (not a valid integer)" do
       let(:params) { {:concurrent_checks => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
     end
 
   end
@@ -105,6 +105,6 @@ describe('icinga2::feature::checker', :type => :class) do
   context "Windows 2012 R2 with concurrent_checks => foo (not a valid integer)" do
     let(:params) { {:concurrent_checks => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 end

--- a/spec/classes/command_spec.rb
+++ b/spec/classes/command_spec.rb
@@ -52,7 +52,7 @@ describe('icinga2::feature::command', :type => :class) do
     context "#{os} with command_path => foo/bar (not an absolute path)" do
       let(:params) { {:command_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
   end
 end
@@ -123,6 +123,6 @@ describe('icinga2::feature::command', :type => :class) do
   context 'Windows 2012 R2 with path => foo/bar (not an absolute path)' do
     let(:params) { {:command_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 end

--- a/spec/classes/compatlog_spec.rb
+++ b/spec/classes/compatlog_spec.rb
@@ -53,7 +53,7 @@ describe('icinga2::feature::compatlog', :type => :class) do
     context "#{os} with rotation_method => foo (not a valid value)" do
       let(:params) { {:rotation_method => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['DAILY', 'HOURLY', 'MONTHLY', 'WEEKLY'\]/) }
     end
 
 
@@ -69,7 +69,7 @@ describe('icinga2::feature::compatlog', :type => :class) do
     context "#{os} with log_dir => foo/bar (not an absolute path)" do
       let(:params) { {:log_dir => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
   end
 end
@@ -141,7 +141,7 @@ describe('icinga2::feature::compatlog', :type => :class) do
   context 'Windows 2012 R2 with rotation_method => foo (not a valid value)' do
     let(:params) { {:rotation_method => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['DAILY', 'HOURLY', 'MONTHLY', 'WEEKLY'\]/) }
   end
 
 
@@ -157,7 +157,7 @@ describe('icinga2::feature::compatlog', :type => :class) do
   context 'Windows 2012 R2 with path => foo/bar (not an absolute path)' do
     let(:params) { {:log_dir => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -22,7 +22,7 @@ describe('icinga2', :type => :class) do
 
     context "#{os} with constants => foo (not a valid hash)" do
       let(:params) { {:constants => 'foo'} }
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
     end
 
 

--- a/spec/classes/debuglog_spec.rb
+++ b/spec/classes/debuglog_spec.rb
@@ -53,7 +53,7 @@ describe('icinga2::feature::debuglog', :type => :class) do
     context "#{os} with path => foo/bar (not an absolute path)" do
       let(:params) { {:path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
   end
 end
@@ -124,6 +124,6 @@ describe('icinga2::feature::debuglog', :type => :class) do
   context 'Windows 2012 R2 with path => foo/bar (not an absolute path)' do
     let(:params) { {:path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 end

--- a/spec/classes/gelf_spec.rb
+++ b/spec/classes/gelf_spec.rb
@@ -53,7 +53,7 @@ describe('icinga2::feature::gelf', :type => :class) do
 
 
     context "#{os} with port => 4247" do
-      let(:params) { {:port => '4247'} }
+      let(:params) { {:port => 4247} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::GelfWriter::gelf')
         .with({ 'target' => '/etc/icinga2/features-available/gelf.conf' })
@@ -64,7 +64,7 @@ describe('icinga2::feature::gelf', :type => :class) do
     context "#{os} with port => foo (not a valid integer)" do
       let(:params) { {:port => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
 
 
@@ -98,7 +98,7 @@ describe('icinga2::feature::gelf', :type => :class) do
     context "#{os} with enable_send_perfdata => foo (not a valid boolean)" do
       let(:params) { {:enable_send_perfdata => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
   end
 end
@@ -170,7 +170,7 @@ describe('icinga2::feature::gelf', :type => :class) do
 
 
   context "Windows 2012 R2 with port => 4247" do
-    let(:params) { {:port => '4247'} }
+    let(:params) { {:port => 4247} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::GelfWriter::gelf')
                             .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/gelf.conf' })
@@ -208,6 +208,6 @@ describe('icinga2::feature::gelf', :type => :class) do
   context "Windows 2012 R2 with enable_send_perfdata => foo (not a valid boolean)" do
     let(:params) { {:enable_send_perfdata => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 end

--- a/spec/classes/graphite_spec.rb
+++ b/spec/classes/graphite_spec.rb
@@ -56,7 +56,7 @@ describe('icinga2::feature::graphite', :type => :class) do
 
 
     context "#{os} with port => 4247" do
-      let(:params) { {:port => '4247'} }
+      let(:params) { {:port => 4247} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::GraphiteWriter::graphite')
         .with({ 'target' => '/etc/icinga2/features-available/graphite.conf' })
@@ -67,7 +67,7 @@ describe('icinga2::feature::graphite', :type => :class) do
     context "#{os} with port => foo (not a valid integer)" do
       let(:params) { {:port => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
 
 
@@ -110,7 +110,7 @@ describe('icinga2::feature::graphite', :type => :class) do
     context "#{os} with enable_send_thresholds => foo (not a valid boolean)" do
       let(:params) { {:enable_send_thresholds => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
 
@@ -135,7 +135,7 @@ describe('icinga2::feature::graphite', :type => :class) do
     context "#{os} with enable_send_metadata => foo (not a valid boolean)" do
       let(:params) { {:enable_send_metadata => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
   end
 end
@@ -209,7 +209,7 @@ describe('icinga2::feature::graphite', :type => :class) do
 
 
   context "Windows 2012 R2 with port => 4247" do
-    let(:params) { {:port => '4247'} }
+    let(:params) { {:port => 4247} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::GraphiteWriter::graphite')
                             .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/graphite.conf' })
@@ -220,7 +220,7 @@ describe('icinga2::feature::graphite', :type => :class) do
   context "Windows 2012 R2 with port => foo (not a valid integer)" do
     let(:params) { {:port => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
   end
 
 
@@ -263,7 +263,7 @@ describe('icinga2::feature::graphite', :type => :class) do
   context "Windows 2012 R2 with enable_send_thresholds => foo (not a valid boolean)" do
     let(:params) { {:enable_send_thresholds => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
 
@@ -288,6 +288,6 @@ describe('icinga2::feature::graphite', :type => :class) do
   context "Windows 2012 R2 with enable_send_metadata => foo (not a valid boolean)" do
     let(:params) { {:enable_send_metadata => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 end

--- a/spec/classes/idomysql_spec.rb
+++ b/spec/classes/idomysql_spec.rb
@@ -55,7 +55,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
 
 
     context "#{os} with port => 4247" do
-      let(:params) { {:port => '4247'} }
+      let(:params) { {:port => 4247} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::IdoMysqlConnection::ido-mysql')
                               .with({ 'target' => '/etc/icinga2/features-available/ido-mysql.conf' })
@@ -66,7 +66,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with port => foo (not a valid integer)" do
       let(:params) { {:port => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
 
 
@@ -82,7 +82,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with socket_path => foo/bar (not an absolute path)" do
       let(:params) { {:socket_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -128,7 +128,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with pki => foo (not a valid value)" do
       let(:params) { {:pki => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /Valid values are 'puppet' and 'none'/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['none', 'puppet'\]/) }
     end
 
 
@@ -159,7 +159,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with enable_ssl = true, ssl_key_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:enable_ssl => true, :ssl_key_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -175,7 +175,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with enable_ssl = true, ssl_cert_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:enable_ssl => true, :ssl_cert_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -191,7 +191,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with enable_ssl = true, ssl_cacert_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:enable_ssl => true, :ssl_cacert_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -218,7 +218,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with enabl_ssl = true, pki = none, ssl_capath = foo" do
       let(:params) { {:enable_ssl => true,:pki => 'none', :ssl_capath => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -261,7 +261,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with enable_ha => foo (not a valid boolean)" do
       let(:params) { {:enable_ha => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
 
@@ -277,7 +277,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with failover_timeout => foo (not a valid value)" do
       let(:params) { {:failover_timeout => "foo"} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
     end
 
 
@@ -293,7 +293,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with cleanup => 'foo' (not a valid hash)" do
       let(:params) { {:cleanup => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
 
 
@@ -309,7 +309,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with categories => 'foo' (not a valid array)" do
       let(:params) { {:categories => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
 
@@ -330,7 +330,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
     context "#{os} with import_schema => foo (not a valid boolean)" do
       let(:params) { {:import_schema => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
 
@@ -412,7 +412,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
 
 
   context "Windows 2012 R2 with port => 4247" do
-    let(:params) { {:port => '4247'} }
+    let(:params) { {:port => 4247} }
 
 
     it { is_expected.to contain_concat__fragment('icinga2::object::IdoMysqlConnection::ido-mysql')
@@ -424,7 +424,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with port => foo (not a valid integer)" do
     let(:params) { {:port => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
   end
 
 
@@ -440,7 +440,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with socket_path => foo/bar (not an absolute path)" do
     let(:params) { {:socket_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -486,7 +486,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with pki => foo (not a valid value)" do
     let(:params) { {:pki => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /Valid values are 'puppet' and 'none'/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['none', 'puppet'\]/) }
   end
 
 
@@ -515,7 +515,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with enable_ssl = true, ssl_key_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:enable_ssl => true, :ssl_key_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -531,7 +531,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with enable_ssl = true, ssl_cert_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:enable_ssl => true, :ssl_cert_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -547,7 +547,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with enable_ssl = true, ssl_cacert_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:enable_ssl => true, :ssl_cacert_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -574,7 +574,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with enabl_ssl = true, pki = none, ssl_capath = foo" do
     let(:params) { {:enable_ssl => true,:pki => 'none', :ssl_capath => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -617,7 +617,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with enable_ha => foo (not a valid boolean)" do
     let(:params) { {:enable_ha => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
 
@@ -633,7 +633,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with failover_timeout => foo (not a valid value)" do
     let(:params) { {:failover_timeout => "foo"} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
   end
 
 
@@ -649,7 +649,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with cleanup => 'foo' (not a valid hash)" do
     let(:params) { {:cleanup => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 
 
@@ -665,7 +665,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with categories => 'foo' (not a valid array)" do
     let(:params) { {:categories => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 
@@ -686,7 +686,7 @@ describe('icinga2::feature::idomysql', :type => :class) do
   context "Windows 2012 R2 with import_schema => foo (not a valid boolean)" do
     let(:params) { {:import_schema => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
   context "Windows 2012 R2 with icinga2::manage_package => true" do

--- a/spec/classes/idopgsql_spec.rb
+++ b/spec/classes/idopgsql_spec.rb
@@ -50,7 +50,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
 
 
     context "#{os} with port => 4247" do
-      let(:params) { {:port => '4247'} }
+      let(:params) { {:port => 4247} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::IdoPgsqlConnection::ido-pgsql')
                               .with({ 'target' => '/etc/icinga2/features-available/ido-pgsql.conf' })
@@ -61,7 +61,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
     context "#{os} with port => foo (not a valid integer)" do
       let(:params) { {:port => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
 
 
@@ -122,7 +122,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
     context "#{os} with enable_ha => foo (not a valid boolean)" do
       let(:params) { {:enable_ha => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
 
@@ -138,7 +138,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
     context "#{os} with failover_timeout => foo (not a valid value)" do
       let(:params) { {:failover_timeout => "foo"} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
     end
 
 
@@ -154,7 +154,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
     context "#{os} with cleanup => 'foo' (not a valid hash)" do
       let(:params) { {:cleanup => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
 
 
@@ -170,7 +170,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
     context "#{os} with categories => 'foo' (not a valid array)" do
       let(:params) { {:categories => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
 
@@ -191,7 +191,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
     context "#{os} with import_schema => foo (not a valid boolean)" do
       let(:params) { {:import_schema => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
     context "#{os} with icinga2::manage_package => true" do
@@ -266,7 +266,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
 
 
   context "Windows 2012 R2 with port => 4247" do
-    let(:params) { {:port => '4247'} }
+    let(:params) { {:port => 4247} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::IdoPgsqlConnection::ido-pgsql')
                             .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/ido-pgsql.conf' })
@@ -277,7 +277,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
   context "Windows 2012 R2 with port => foo (not a valid integer)" do
     let(:params) { {:port => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
   end
 
 
@@ -338,7 +338,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
   context "Windows 2012 R2 with enable_ha => foo (not a valid boolean)" do
     let(:params) { {:enable_ha => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
 
@@ -354,7 +354,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
   context "Windows 2012 R2 with failover_timeout => foo (not a valid value)" do
     let(:params) { {:failover_timeout => "foo"} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
   end
 
 
@@ -370,7 +370,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
   context "Windows 2012 R2 with cleanup => 'foo' (not a valid hash)" do
     let(:params) { {:cleanup => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 
 
@@ -386,7 +386,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
   context "Windows 2012 R2 with categories => 'foo' (not a valid array)" do
     let(:params) { {:categories => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 
@@ -407,7 +407,7 @@ describe('icinga2::feature::idopgsql', :type => :class) do
   context "Windows 2012 R2 with import_schema => foo (not a valid boolean)" do
     let(:params) { {:import_schema => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
   context "Windows 2012 R2 with icinga2::manage_package => true" do

--- a/spec/classes/influxdb_spec.rb
+++ b/spec/classes/influxdb_spec.rb
@@ -70,7 +70,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with port => foo (not a valid integer)" do
       let(:params) { {:port => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
 
 
@@ -126,7 +126,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with pki => foo (not a valid value)" do
       let(:params) { {:pki => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /Valid values are 'puppet' and 'none'/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['none', 'puppet'\]/) }
     end
 
 
@@ -157,7 +157,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with enable_ssl = true, ssl_key_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:enable_ssl => true, :ssl_key_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -173,7 +173,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with enable_ssl = true, ssl_cert_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:enable_ssl => true, :ssl_cert_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -189,7 +189,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with enable_ssl = true, ssl_cacert_path = foo/bar (not a valid absolute path)" do
       let(:params) { {:enable_ssl => true, :ssl_cacert_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -214,7 +214,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with host_tags => 'foo' (not a valid hash)" do
       let(:params) { {:host_tags => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
     end
 
 
@@ -239,7 +239,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with service_tags => 'foo' (not a valid hash)" do
       let(:params) { {:service_tags => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
     end
 
 
@@ -264,7 +264,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with enable_send_thresholds => foo (not a valid boolean)" do
       let(:params) { {:enable_send_thresholds => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
 
@@ -289,7 +289,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with enable_send_metadata => foo (not a valid boolean)" do
       let(:params) { {:enable_send_metadata => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
     context "#{os} with flush_interval => 50s" do
@@ -304,12 +304,12 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with flush_interval => foo (not a valid value)" do
       let(:params) { {:flush_interval => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
     end
 
 
     context "#{os} with flush_threshold => 2048" do
-      let(:params) { {:flush_threshold => '2048'} }
+      let(:params) { {:flush_threshold => 2048} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::InfluxdbWriter::influxdb')
                               .with({ 'target' => '/etc/icinga2/features-available/influxdb.conf' })
@@ -320,7 +320,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
     context "#{os} with flush_threshold => foo (not a valid integer)" do
       let(:params) { {:flush_threshold => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
   end
 end
@@ -409,7 +409,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with port => foo (not a valid integer)" do
     let(:params) { {:port => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
   end
 
 
@@ -465,7 +465,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with pki => foo (not a valid value)" do
     let(:params) { {:pki => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /Valid values are 'puppet' and 'none'/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['none', 'puppet'\]/) }
   end
 
 
@@ -495,7 +495,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with enable_ssl = true, ssl_key_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:enable_ssl => true, :ssl_key_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -511,7 +511,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with enable_ssl = true, ssl_cert_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:enable_ssl => true, :ssl_cert_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -527,7 +527,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with enable_ssl = true, ssl_cacert_path = foo/bar (not a valid absolute path)" do
     let(:params) { {:enable_ssl => true, :ssl_cacert_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -552,7 +552,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with host_tags => 'foo' (not a valid hash)" do
     let(:params) { {:host_tags => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
   end
 
 
@@ -577,7 +577,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with service_tags => 'foo' (not a valid hash)" do
     let(:params) { {:service_tags => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Hash value/) }
   end
 
 
@@ -602,7 +602,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with enable_send_thresholds => foo (not a valid boolean)" do
     let(:params) { {:enable_send_thresholds => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
 
@@ -627,7 +627,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with enable_send_metadata => foo (not a valid boolean)" do
     let(:params) { {:enable_send_metadata => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
   context "Windows 2012 R2 with flush_interval => 50s" do
@@ -642,12 +642,12 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with flush_interval => foo (not a valid value)" do
     let(:params) { {:flush_interval => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
   end
 
 
   context "Windows 2012 R2 with flush_threshold => 2048" do
-    let(:params) { {:flush_threshold => '2048'} }
+    let(:params) { {:flush_threshold => 2048} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::InfluxdbWriter::influxdb')
                             .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/influxdb.conf' })
@@ -658,7 +658,7 @@ describe('icinga2::feature::influxdb', :type => :class) do
   context "Windows 2012 R2 with flush_threshold => foo (not a valid integer)" do
     let(:params) { {:flush_threshold => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
   end
 
 end

--- a/spec/classes/livestatus_spec.rb
+++ b/spec/classes/livestatus_spec.rb
@@ -57,7 +57,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
     context "#{os} with socket_type => foo (not a valid value)" do
       let(:params) { {:socket_type => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /foo isn't supported. Valid values are 'unix' and 'tcp'./) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['tcp', 'unix'\]/) }
     end
 
 
@@ -71,7 +71,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
 
 
     context "#{os} with bind_port => 4247" do
-      let(:params) { {:bind_port => '4247'} }
+      let(:params) { {:bind_port => 4247} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::LivestatusListener::livestatus')
         .with({ 'target' => '/etc/icinga2/features-available/livestatus.conf' })
@@ -82,7 +82,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
     context "#{os} with bind_port => foo (not a valid integer)" do
       let(:params) { {:bind_port => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
 
 
@@ -98,7 +98,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
     context "#{os} with socket_path => foo/bar (not an absolute path)" do
       let(:params) { {:socket_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -114,7 +114,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
     context "#{os} with compat_log_path => foo/bar (not an absolute path)" do
       let(:params) { {:compat_log_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
   end
 end
@@ -188,7 +188,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
   context 'Windows 2012 R2 with socket_type => foo (not a valid value)' do
     let(:params) { {:socket_type => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /foo isn't supported. Valid values are 'unix' and 'tcp'./) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['tcp', 'unix'\]/) }
   end
 
 
@@ -202,7 +202,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
 
 
   context "Windows 2012 R2 with bind_port => 4247" do
-    let(:params) { {:bind_port => '4247'} }
+    let(:params) { {:bind_port => 4247} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::LivestatusListener::livestatus')
                             .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/livestatus.conf' })
@@ -213,7 +213,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
   context "Windows 2012 R2 with bind_port => foo (not a valid integer)" do
     let(:params) { {:bind_port => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
   end
 
 
@@ -229,7 +229,7 @@ describe('icinga2::feature::livestatus', :type => :class) do
   context 'Windows 2012 R2 with socket_path => foo/bar (not an absolute path)' do
     let(:params) { {:socket_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -245,6 +245,6 @@ describe('icinga2::feature::livestatus', :type => :class) do
   context 'Windows 2012 R2 with compat_log_path => foo/bar (not an absolute path)' do
     let(:params) { {:compat_log_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 end

--- a/spec/classes/mainlog_spec.rb
+++ b/spec/classes/mainlog_spec.rb
@@ -58,7 +58,7 @@ describe('icinga2::feature::mainlog', :type => :class) do
     context "#{os} with severity => foo (not a valid value)" do
       let(:params) { {:severity => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['debug', 'information', 'notice', 'warning'\]/) }
     end
 
 
@@ -74,7 +74,7 @@ describe('icinga2::feature::mainlog', :type => :class) do
     context "#{os} with path => foo/bar (not an absolute path)" do
       let(:params) { {:path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
   end
 
@@ -152,7 +152,7 @@ describe('icinga2::feature::mainlog', :type => :class) do
   context 'Windows 2012 R2 with severity => foo (not a valid value)' do
     let(:params) { {:severity => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['debug', 'information', 'notice', 'warning'\]/) }
   end
 
 
@@ -168,6 +168,6 @@ describe('icinga2::feature::mainlog', :type => :class) do
   context 'Windows 2012 R2 with path => foo/bar (not an absolute path)' do
     let(:params) { {:path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 end

--- a/spec/classes/notification_spec.rb
+++ b/spec/classes/notification_spec.rb
@@ -52,7 +52,7 @@ describe('icinga2::feature::notification', :type => :class) do
     context "#{os} with enable_ha = foo (not a valid boolean)" do
       let(:params) { {:enable_ha => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
   end
 end
@@ -123,6 +123,6 @@ describe('icinga2::feature::notification', :type => :class) do
   context "Windows 2012 R2 with enable_ha = foo (not a valid boolean)" do
     let(:params) { {:enable_ha => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 end

--- a/spec/classes/opentsdb_spec.rb
+++ b/spec/classes/opentsdb_spec.rb
@@ -52,7 +52,7 @@ describe('icinga2::feature::opentsdb', :type => :class) do
 
 
     context "#{os} with port => 4247" do
-      let(:params) { {:port => '4247'} }
+      let(:params) { {:port => 4247} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::OpenTsdbWriter::opentsdb')
         .with({ 'target' => '/etc/icinga2/features-available/opentsdb.conf' })
@@ -63,7 +63,7 @@ describe('icinga2::feature::opentsdb', :type => :class) do
     context "#{os} with port => foo (not a valid integer)" do
       let(:params) { {:port => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
     end
   end
 end
@@ -133,7 +133,7 @@ describe('icinga2::feature::opentsdb', :type => :class) do
 
 
   context "Windows 2012 R2 with port => 4247" do
-    let(:params) { {:port => '4247'} }
+    let(:params) { {:port => 4247} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::OpenTsdbWriter::opentsdb')
                             .with({ 'target' => 'C:/ProgramData/icinga2/etc/icinga2/features-available/opentsdb.conf' })
@@ -144,6 +144,6 @@ describe('icinga2::feature::opentsdb', :type => :class) do
   context "Windows 2012 R2 with port => foo (not a valid integer)" do
     let(:params) { {:port => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Integer value/) }
   end
 end

--- a/spec/classes/perfdata_spec.rb
+++ b/spec/classes/perfdata_spec.rb
@@ -57,7 +57,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
     context "#{os} with rotation_interval => foo (not a valid value)" do
       let(:params) { {:rotation_interval => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
     end
 
 
@@ -73,7 +73,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
     context "#{os} with host_perfdata_path => foo/bar (not an absolute path)" do
       let(:params) { {:host_perfdata_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -89,7 +89,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
     context "#{os} with service_perfdata_path => foo/bar (not an absolute path)" do
       let(:params) { {:service_perfdata_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -105,7 +105,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
     context "#{os} with host_temp_path => foo/bar (not an absolute path)" do
       let(:params) { {:host_temp_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -121,7 +121,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
     context "#{os} with service_temp_path => foo/bar (not an absolute path)" do
       let(:params) { {:service_temp_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -215,7 +215,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
   context 'Windows 2012 R2 with rotation_interval => foo (not a valid value)' do
     let(:params) { {:rotation_interval => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
   end
 
 
@@ -231,7 +231,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
   context 'Windows 2012 R2 with host_perfdata_path => foo/bar (not an absolute path)' do
     let(:params) { {:host_perfdata_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -247,7 +247,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
   context 'Windows 2012 R2 with service_perfdata_path => foo/bar (not an absolute path)' do
     let(:params) { {:service_perfdata_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -263,7 +263,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
   context 'Windows 2012 R2 with host_temp_path => foo/bar (not an absolute path)' do
     let(:params) { {:host_temp_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -279,7 +279,7 @@ describe('icinga2::feature::perfdata', :type => :class) do
   context 'Windows 2012 R2 with service_temp_path => foo/bar (not an absolute path)' do
     let(:params) { {:service_temp_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -29,13 +29,13 @@ describe('icinga2', :type => :class) do
     context "#{os} with ensure => foo (not a valid boolean)" do
       let(:params) { {:ensure => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /foo isn't supported. Valid values are 'running' and 'stopped'./) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['running', 'stopped'\]/) }
     end
 
     context "#{os} with enable => foo (not a valid boolean)" do
       let(:params) { {:enable => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
     context "#{os} with manage_service => true" do
@@ -51,7 +51,7 @@ describe('icinga2', :type => :class) do
     context "#{os} with manage_service => foo (not a valid boolean)" do
       let(:params) { {:manage_service => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
   end
 end
@@ -90,13 +90,13 @@ describe('icinga2', :type => :class) do
   context "windows with ensure => foo (not a valid boolean)" do
     let(:params) { {:ensure => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /foo isn't supported. Valid values are 'running' and 'stopped'./) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['running', 'stopped'\]/) }
   end
 
   context "windows with enable => foo (not a valid boolean)" do
     let(:params) { {:enable => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
   context "windows with manage_service => true" do
@@ -114,6 +114,6 @@ describe('icinga2', :type => :class) do
   context "windows with manage_service => foo (not a valid boolean)" do
     let(:params) { {:manage_service => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 end

--- a/spec/classes/statusdata_spec.rb
+++ b/spec/classes/statusdata_spec.rb
@@ -55,7 +55,7 @@ describe('icinga2::feature::statusdata', :type => :class) do
     context "#{os} with update_interval => foo (not a valid value)" do
       let(:params) { {:update_interval => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
     end
 
 
@@ -71,7 +71,7 @@ describe('icinga2::feature::statusdata', :type => :class) do
     context "#{os} with status_path => foo/bar (not an absolute path)" do
       let(:params) { {:status_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -87,7 +87,7 @@ describe('icinga2::feature::statusdata', :type => :class) do
     context "#{os} with objects_path => foo/bar (not an absolute path)" do
       let(:params) { {:objects_path => 'foo/bar'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
   end
 
@@ -163,7 +163,7 @@ describe('icinga2::feature::statusdata', :type => :class) do
   context 'Windows 2012 R2 with update_interval => foo (not a valid value)' do
     let(:params) { {:update_interval => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\[ms\]\*\$\/\]/) }
   end
 
 
@@ -179,7 +179,7 @@ describe('icinga2::feature::statusdata', :type => :class) do
   context 'Windows 2012 R2 with status_path => foo/bar (not an absolute path)' do
     let(:params) { {:status_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -195,6 +195,6 @@ describe('icinga2::feature::statusdata', :type => :class) do
   context 'Windows 2012 R2 with objects_path => foo/bar (not an absolute path)' do
     let(:params) { {:objects_path => 'foo/bar'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 end

--- a/spec/classes/syslog_spec.rb
+++ b/spec/classes/syslog_spec.rb
@@ -53,7 +53,7 @@ describe('icinga2::feature::syslog', :type => :class) do
     context "#{os} with severity => foo (not a valid value)" do
       let(:params) { {:severity => 'foo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['debug', 'information', 'notice', 'warning'\]/) }
     end
   end
 
@@ -125,6 +125,6 @@ describe('icinga2::feature::syslog', :type => :class) do
   context 'Windows 2012 R2 with severity => foo (not a valid value)' do
     let(:params) { {:severity => 'foo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['debug', 'information', 'notice', 'warning'\]/) }
   end
 end

--- a/spec/defines/apiuser_spec.rb
+++ b/spec/defines/apiuser_spec.rb
@@ -30,7 +30,7 @@ describe('icinga2::object::apiuser', :type => :define) do
     context "#{os} with target => bar/baz (not valid absolute path)" do
       let(:params) { {:target => 'bar/baz', :permissions => ['*']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -64,7 +64,7 @@ describe('icinga2::object::apiuser', :type => :define) do
     context "#{os} with permissions => foo (not a valid array)" do
       let(:params) { {:permissions => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
     end
   end
 end
@@ -110,7 +110,7 @@ describe('icinga2::object::apiuser', :type => :define) do
   context "Windows 2012 R2  with target => C:bar/baz (not valid absolute path)" do
     let(:params) { {:target => 'C:bar/baz', :permissions => ['*']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"C:bar\/baz" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -144,6 +144,6 @@ describe('icinga2::object::apiuser', :type => :define) do
   context "Windows 2012 R2  with permissions => foo (not a valid array)" do
     let(:params) { {:permissions => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
   end
 end

--- a/spec/defines/checkcommand_spec.rb
+++ b/spec/defines/checkcommand_spec.rb
@@ -44,12 +44,12 @@ describe('icinga2::object::checkcommand', :type => :define) do
     context "#{os} with env => foo (not a valid hash)" do
       let(:params) { {:env => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
 
 
     context "#{os} with timeout => 30" do
-      let(:params) { {:timeout => '30', :target => '/bar/baz', :command => ['foocommand']} }
+      let(:params) { {:timeout => 30, :target => '/bar/baz', :command => ['foocommand']} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::CheckCommand::bar')
         .with({'target' => '/bar/baz'})
@@ -60,7 +60,7 @@ describe('icinga2::object::checkcommand', :type => :define) do
     context "#{os} with timeout => foo (not a valid integer)" do
       let(:params) { {:timeout => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
      end
 
 
@@ -76,7 +76,7 @@ describe('icinga2::object::checkcommand', :type => :define) do
     context "#{os} with arguments => foo (not a valid hash)" do
       let(:params) { {:arguments => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
   end
 end
@@ -137,12 +137,12 @@ describe('icinga2::object::checkcommand', :type => :define) do
   context "Windows 2012 R2 with env => foo (not a valid hash)" do
     let(:params) { {:env => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 
 
   context "Windows 2012 R2 with timeout => 30" do
-    let(:params) { {:timeout => '30', :target => 'C:/bar/baz', :command => ['foocommand']} }
+    let(:params) { {:timeout => 30, :target => 'C:/bar/baz', :command => ['foocommand']} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::CheckCommand::bar')
       .with({'target' => 'C:/bar/baz'})
@@ -153,7 +153,7 @@ describe('icinga2::object::checkcommand', :type => :define) do
   context "Windows 2012 R2 with timeout => foo (not a valid integer)" do
     let(:params) { {:timeout => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 
 
@@ -169,6 +169,6 @@ describe('icinga2::object::checkcommand', :type => :define) do
   context "Windows 2012 R2 with arguments => foo (not a valid hash)" do
     let(:params) { {:arguments => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 end

--- a/spec/defines/checkresultreader_spec.rb
+++ b/spec/defines/checkresultreader_spec.rb
@@ -50,7 +50,7 @@ describe('icinga2::object::checkresultreader', :type => :define) do
     context "#{os} with spool_dir = foo/bar (not a valid absolute path)" do
       let(:params) { {:spool_dir => 'foo/bar', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
   end
 end
@@ -119,6 +119,6 @@ describe('icinga2::object::checkresultreader', :type => :define) do
   context "Windows 2012 R2 with spool_dir = foo/bar (not a valid absolute path)" do
     let(:params) { {:spool_dir => 'foo/bar', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 end

--- a/spec/defines/compatlogger_spec.rb
+++ b/spec/defines/compatlogger_spec.rb
@@ -51,7 +51,7 @@ describe('icinga2::object::compatlogger', :type => :define) do
     context "#{os} with log_dir = foo/bar (not a valid absolute path)" do
       let(:params) { {:log_dir => 'foo/bar', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -66,7 +66,7 @@ describe('icinga2::object::compatlogger', :type => :define) do
     context "#{os} with rotation_method = 'foo' (not a valid absolute path)" do
       let(:params) { {:rotation_method => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+    	it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['DAILY', 'HOURLY', 'MONTHLY', 'WEEKLY'\]/) }
     end
   end
 end
@@ -135,7 +135,7 @@ describe('icinga2::object::compatlogger', :type => :define) do
   context "Windows 2012 R2 with log_dir = foo/bar (not a valid absolute path)" do
     let(:params) { {:log_dir => 'foo/bar', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -150,6 +150,6 @@ describe('icinga2::object::compatlogger', :type => :define) do
   context "Windows 2012 R2 with rotation_method = 'foo' (not a valid absolute path)" do
     let(:params) { {:rotation_method => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['DAILY', 'HOURLY', 'MONTHLY', 'WEEKLY'\]/) }
   end
 end

--- a/spec/defines/dependency_spec.rb
+++ b/spec/defines/dependency_spec.rb
@@ -109,7 +109,7 @@ describe('icinga2::object::dependency', :type => :define) do
           :parent_host_name => 'parentfoo',
           :child_host_name => 'childfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -133,7 +133,7 @@ describe('icinga2::object::dependency', :type => :define) do
           :parent_host_name => 'parentfoo',
           :child_host_name => 'childfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -157,7 +157,7 @@ describe('icinga2::object::dependency', :type => :define) do
           :parent_host_name => 'parentfoo',
           :child_host_name => 'childfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -194,7 +194,7 @@ describe('icinga2::object::dependency', :type => :define) do
           :parent_host_name => 'parentfoo',
           :child_host_name => 'childfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
   end
 end
@@ -321,7 +321,7 @@ describe('icinga2::object::dependency', :type => :define) do
         :parent_host_name => 'parentfoo',
         :child_host_name => 'childfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -345,7 +345,7 @@ describe('icinga2::object::dependency', :type => :define) do
         :parent_host_name => 'parentfoo',
         :child_host_name => 'childfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -369,7 +369,7 @@ describe('icinga2::object::dependency', :type => :define) do
         :parent_host_name => 'parentfoo',
         :child_host_name => 'childfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -406,6 +406,6 @@ describe('icinga2::object::dependency', :type => :define) do
         :parent_host_name => 'parentfoo',
         :child_host_name => 'childfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 end

--- a/spec/defines/endpoint_spec.rb
+++ b/spec/defines/endpoint_spec.rb
@@ -35,14 +35,14 @@ describe('icinga2::object::endpoint', :type => :define) do
     context "#{os} with ensure => foo (not a valid value)" do
       let(:params) { {:ensure => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['absent', 'present'\]/) }
     end
 
 
     context "#{os} with target => bar/baz (not valid absolute path)" do
       let(:params) { {:target => 'bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -55,7 +55,7 @@ describe('icinga2::object::endpoint', :type => :define) do
 
 
     context "#{os} with port => 4247" do
-      let(:params) { {:port => '4247', :target => '/bar/baz'} }
+      let(:params) { {:port => 4247, :target => '/bar/baz'} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::Endpoint::bar')
         .with_content(/port = 4247/) }
@@ -65,7 +65,7 @@ describe('icinga2::object::endpoint', :type => :define) do
     context "#{os} with port => foo (not a valid integer)" do
       let(:params) { {:port => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
     end
 
 
@@ -80,7 +80,7 @@ describe('icinga2::object::endpoint', :type => :define) do
     context "#{os} with log_duration => foo (not a valid value)" do
       let(:params) { {:log_duration => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
     end
   end
 end
@@ -132,14 +132,14 @@ describe('icinga2::object::endpoint', :type => :define) do
   context "Windows 2012 R2 with ensure => foo (not a valid value)" do
     let(:params) { {:ensure => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['absent', 'present'\]/) }
   end
 
 
   context "Windows 2012 R2  with target => bar/baz (not valid absolute path)" do
     let(:params) { {:target => 'bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -152,7 +152,7 @@ describe('icinga2::object::endpoint', :type => :define) do
 
 
   context "Windows 2012 R2  with port => 4247" do
-    let(:params) { {:port => '4247', :target => 'C:/bar/baz'} }
+    let(:params) { {:port => 4247, :target => 'C:/bar/baz'} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::Endpoint::bar')
                             .with_content(/port = 4247/) }
@@ -162,7 +162,7 @@ describe('icinga2::object::endpoint', :type => :define) do
   context "Windows 2012 R2  with port => foo (not a valid integer)" do
     let(:params) { {:port => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 
 
@@ -177,6 +177,6 @@ describe('icinga2::object::endpoint', :type => :define) do
   context "Windows 2012 R2  with log_duration => foo (not a valid value)" do
     let(:params) { {:log_duration => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
   end
 end

--- a/spec/defines/eventcommand_spec.rb
+++ b/spec/defines/eventcommand_spec.rb
@@ -65,7 +65,7 @@ describe('icinga2::object::eventcommand', :type => :define) do
     context "#{os} with env => 'foo' (not a valid hash)" do
       let(:params) { {:env => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
 
 
@@ -80,7 +80,7 @@ describe('icinga2::object::eventcommand', :type => :define) do
 
 
     context "#{os} with timeout => 30" do
-      let(:params) { {:timeout => '30', :target => '/bar/baz', :command => ['foocommand']} }
+      let(:params) { {:timeout => 30, :target => '/bar/baz', :command => ['foocommand']} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::EventCommand::bar')
                               .with({'target' => '/bar/baz'})
@@ -91,7 +91,7 @@ describe('icinga2::object::eventcommand', :type => :define) do
     context "#{os} with timeout => foo (not a valid integer)" do
       let(:params) { {:timeout => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
     end
 
 
@@ -110,7 +110,7 @@ describe('icinga2::object::eventcommand', :type => :define) do
     context "#{os} with arguments => foo (not a valid hash)" do
       let(:params) { {:arguments => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
   end
 end
@@ -195,7 +195,7 @@ describe('icinga2::object::eventcommand', :type => :define) do
   context "Windows 2012 R2 with env => 'foo' (not a valid hash)" do
     let(:params) { {:env => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 
 
@@ -210,7 +210,7 @@ describe('icinga2::object::eventcommand', :type => :define) do
 
 
   context "Windows 2012 R2 with timeout => 30" do
-    let(:params) { {:timeout => '30', :target => 'C:/bar/baz', :command => ['foocommand']} }
+    let(:params) { {:timeout => 30, :target => 'C:/bar/baz', :command => ['foocommand']} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::EventCommand::bar')
                             .with({'target' => 'C:/bar/baz'})
@@ -221,7 +221,7 @@ describe('icinga2::object::eventcommand', :type => :define) do
   context "Windows 2012 R2 with timeout => foo (not a valid integer)" do
     let(:params) { {:timeout => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 
 
@@ -239,7 +239,7 @@ describe('icinga2::object::eventcommand', :type => :define) do
   context "Windows 2012 R2 with arguments => foo (not a valid hash)" do
     let(:params) { {:arguments => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 
 end

--- a/spec/defines/feature_spec.rb
+++ b/spec/defines/feature_spec.rb
@@ -15,6 +15,11 @@ describe('icinga2::feature', :type => :define) do
     ]
   end
 
+	before(:each) do
+		# Fake assert_private function from stdlib to not fail within this test
+		Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) { |args|
+		}
+	end
 
   on_supported_os.each do |os, facts|
     let :facts do
@@ -28,7 +33,7 @@ describe('icinga2::feature', :type => :define) do
       it do
         expect {
           should contain_icinga2__feature('foo')
-        }.to raise_error(Puppet::Error, /foo isn't supported. Valid values are 'present' and 'absent'./)
+        }.to raise_error(Puppet::Error, /expects a match for Enum\['absent', 'present'\]/)
       end
     end
 
@@ -87,6 +92,12 @@ describe('icinga2::feature', :type => :define) do
       }"
     ]
   end
+
+	before(:each) do
+		# Fake assert_private function from stdlib to not fail within this test
+		Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) { |args|
+		}
+	end
 
   context 'Windows 2012 R2 with ensure => present, feature => foo' do
     let(:params) { {:ensure => 'present', 'feature' => 'foo'} }

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -27,7 +27,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with target => bar/baz (not valid absolute path)" do
       let(:params) { {:target => 'bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -43,7 +43,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with import => foo (not a valid array)" do
       let(:params) { {:import => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
     end
 
 
@@ -86,7 +86,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with groups => foo (not a valid array)" do
       let(:params) { {:groups => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
 
@@ -113,7 +113,7 @@ describe('icinga2::object::host', :type => :define) do
 
 
     context "#{os} with max_check_attempts => 3" do
-      let(:params) { {:max_check_attempts => '3', :target => '/bar/baz', :check_command => 'foocommand'} }
+      let(:params) { {:max_check_attempts => 3, :target => '/bar/baz', :check_command => 'foocommand'} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::Host::bar')
         .with({'target' => '/bar/baz'})
@@ -124,7 +124,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with max_check_attempts => foo (not a valid integer)" do
       let(:params) { {:max_check_attempts => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
     end
 
 
@@ -149,7 +149,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with check_timeout => foo (not a valid value)" do
       let(:params) { {:check_timeout => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
     end
 
 
@@ -165,7 +165,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with check_interval => foo (not a valid value)" do
       let(:params) { {:check_interval => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
     end
 
 
@@ -181,7 +181,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with retry_interval => foo (not a valid value)" do
       let(:params) { {:retry_interval => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
     end
 
 
@@ -206,7 +206,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with enable_notifications => foo (not a valid boolean)" do
       let(:params) { {:enable_notifications => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -231,7 +231,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with enable_active_checks => foo (not a valid boolean)" do
       let(:params) { {:enable_active_checks => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -256,7 +256,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with enable_passive_checks => foo (not a valid boolean)" do
       let(:params) { {:enable_passive_checks => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -281,7 +281,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with enable_event_handler => foo (not a valid boolean)" do
       let(:params) { {:enable_event_handler => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -306,7 +306,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with enable_flapping => foo (not a valid boolean)" do
       let(:params) { {:enable_flapping => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -331,7 +331,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with enable_perfdata => foo (not a valid boolean)" do
       let(:params) { {:enable_perfdata => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -345,7 +345,7 @@ describe('icinga2::object::host', :type => :define) do
 
 
     context "#{os} with flapping_threshold => 30" do
-      let(:params) { {:flapping_threshold => '30', :target => '/bar/baz', :check_command => 'foocommand'} }
+      let(:params) { {:flapping_threshold => 30, :target => '/bar/baz', :check_command => 'foocommand'} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::Host::bar')
         .with({'target' => '/bar/baz'})
@@ -356,7 +356,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with flapping_threshold => foo (not a valid integer)" do
       let(:params) { {:flapping_threshold => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
     end
 
 
@@ -372,7 +372,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with volatile => foo (not a valid boolean)" do
       let(:params) { {:volatile => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -433,7 +433,7 @@ describe('icinga2::object::host', :type => :define) do
     context "#{os} with icon_image => foo/foobar (not valid absolute path)" do
       let(:params) { {:icon_image => 'foo/foobar', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/foobar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -489,7 +489,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with target => bar/baz (not valid absolute path)" do
     let(:params) { {:target => 'bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -505,7 +505,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with import => foo (not a valid array)" do
     let(:params) { {:import => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
   end
 
 
@@ -548,7 +548,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with groups => foo (not a valid array)" do
     let(:params) { {:groups => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 
@@ -575,7 +575,7 @@ describe('icinga2::object::host', :type => :define) do
 
 
   context "Windows 2012 R2 with max_check_attempts => 3" do
-    let(:params) { {:max_check_attempts => '3', :target => '/bar/baz', :check_command => 'foocommand'} }
+    let(:params) { {:max_check_attempts => 3, :target => '/bar/baz', :check_command => 'foocommand'} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::Host::bar')
                             .with({'target' => '/bar/baz'})
@@ -586,7 +586,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with max_check_attempts => foo (not a valid integer)" do
     let(:params) { {:max_check_attempts => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 
 
@@ -611,7 +611,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with check_timeout => foo (not a valid value)" do
     let(:params) { {:check_timeout => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
   end
 
 
@@ -627,7 +627,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with check_interval => foo (not a valid value)" do
     let(:params) { {:check_interval => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
   end
 
 
@@ -643,7 +643,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with retry_interval => foo (not a valid value)" do
     let(:params) { {:retry_interval => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
   end
 
 
@@ -668,7 +668,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with enable_notifications => foo (not a valid boolean)" do
     let(:params) { {:enable_notifications => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -693,7 +693,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with enable_active_checks => foo (not a valid boolean)" do
     let(:params) { {:enable_active_checks => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -718,7 +718,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with enable_passive_checks => foo (not a valid boolean)" do
     let(:params) { {:enable_passive_checks => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -743,7 +743,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with enable_event_handler => foo (not a valid boolean)" do
     let(:params) { {:enable_event_handler => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -768,7 +768,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with enable_flapping => foo (not a valid boolean)" do
     let(:params) { {:enable_flapping => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -793,7 +793,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with enable_perfdata => foo (not a valid boolean)" do
     let(:params) { {:enable_perfdata => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -807,7 +807,7 @@ describe('icinga2::object::host', :type => :define) do
 
 
   context "Windows 2012 R2 with flapping_threshold => 30" do
-    let(:params) { {:flapping_threshold => '30', :target => '/bar/baz', :check_command => 'foocommand'} }
+    let(:params) { {:flapping_threshold => 30, :target => '/bar/baz', :check_command => 'foocommand'} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::Host::bar')
                             .with({'target' => '/bar/baz'})
@@ -818,7 +818,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with flapping_threshold => foo (not a valid integer)" do
     let(:params) { {:flapping_threshold => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 
 
@@ -834,7 +834,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with volatile => foo (not a valid boolean)" do
     let(:params) { {:volatile => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -895,7 +895,7 @@ describe('icinga2::object::host', :type => :define) do
   context "Windows 2012 R2 with icon_image => foo/foobar (not valid absolute path)" do
     let(:params) { {:icon_image => 'foo/foobar', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/foobar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 

--- a/spec/defines/hostgroup_spec.rb
+++ b/spec/defines/hostgroup_spec.rb
@@ -49,7 +49,7 @@ describe('icinga2::object::hostgroup', :type => :define) do
     context "#{os} with groups => foo (not a valid array)" do
       let(:params) { {:groups => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
 
@@ -121,7 +121,7 @@ describe('icinga2::object::hostgroup', :type => :define) do
   context "Windows 2012 R2   with groups => foo (not a valid array)" do
     let(:params) { {:groups => 'foo', :target => '/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 

--- a/spec/defines/notification_spec.rb
+++ b/spec/defines/notification_spec.rb
@@ -110,7 +110,7 @@ describe('icinga2::object::notification', :type => :define) do
     context "#{os} with times => 'foo' (not a valid hash)" do
       let(:params) { {:times => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
 
 
@@ -144,7 +144,7 @@ describe('icinga2::object::notification', :type => :define) do
     context "#{os} with interval => foo (not a valid integer)" do
       let(:params) { {:interval => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
     end
 
 
@@ -315,7 +315,7 @@ describe('icinga2::object::notification', :type => :define) do
   context "Windows 2012 R2 with times => 'foo' (not a valid hash)" do
     let(:params) { {:times => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 
 
@@ -349,7 +349,7 @@ describe('icinga2::object::notification', :type => :define) do
   context "Windows 2012 R2 with interval => foo (not a valid integer)" do
     let(:params) { {:interval => 'foo', :target => '/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
   end
 
 

--- a/spec/defines/notificationcommand_spec.rb
+++ b/spec/defines/notificationcommand_spec.rb
@@ -65,7 +65,7 @@ describe('icinga2::object::notificationcommand', :type => :define) do
     context "#{os} with env => 'foo' (not a valid hash)" do
       let(:params) { {:env => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
 
 
@@ -80,7 +80,7 @@ describe('icinga2::object::notificationcommand', :type => :define) do
 
 
     context "#{os} with timeout => 30" do
-      let(:params) { {:timeout => '30', :target => '/bar/baz', :command => ['foocommand']} }
+      let(:params) { {:timeout => 30, :target => '/bar/baz', :command => ['foocommand']} }
 
       it { is_expected.to contain_concat__fragment('icinga2::object::NotificationCommand::bar')
                               .with({'target' => '/bar/baz'})
@@ -91,7 +91,7 @@ describe('icinga2::object::notificationcommand', :type => :define) do
     context "#{os} with timeout => foo (not a valid integer)" do
       let(:params) { {:timeout => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
     end
 
 
@@ -110,7 +110,7 @@ describe('icinga2::object::notificationcommand', :type => :define) do
     context "#{os} with arguments => foo (not a valid hash)" do
       let(:params) { {:arguments => 'foo', :target => '/bar/baz', :command => ['foocommand']} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
   end
 end
@@ -194,7 +194,7 @@ describe('icinga2::object::notificationcommand', :type => :define) do
   context "Windows 2012 R2 with env => 'foo' (not a valid hash)" do
     let(:params) { {:env => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 
 
@@ -209,7 +209,7 @@ describe('icinga2::object::notificationcommand', :type => :define) do
 
 
   context "Windows 2012 R2 with timeout => 30" do
-    let(:params) { {:timeout => '30', :target => 'C:/bar/baz', :command => ['foocommand']} }
+    let(:params) { {:timeout => 30, :target => 'C:/bar/baz', :command => ['foocommand']} }
 
     it { is_expected.to contain_concat__fragment('icinga2::object::NotificationCommand::bar')
                             .with({'target' => 'C:/bar/baz'})
@@ -220,7 +220,7 @@ describe('icinga2::object::notificationcommand', :type => :define) do
   context "Windows 2012 R2 with timeout => foo (not a valid integer)" do
     let(:params) { {:timeout => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 
 
@@ -239,6 +239,6 @@ describe('icinga2::object::notificationcommand', :type => :define) do
   context "Windows 2012 R2 with arguments => foo (not a valid hash)" do
     let(:params) { {:arguments => 'foo', :target => 'C:/bar/baz', :command => ['foocommand']} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 end

--- a/spec/defines/object_spec.rb
+++ b/spec/defines/object_spec.rb
@@ -6,6 +6,12 @@ describe('icinga2::object', :type => :define) do
     "class { 'icinga2': }"
   ] }
 
+	before(:each) do
+		# Fake assert_private function from stdlib to not fail within this test
+		Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) { |args|
+		}
+	end
+
   on_supported_os.each do |os, facts|
     let :facts do
       facts
@@ -37,14 +43,14 @@ describe('icinga2::object', :type => :define) do
     context "#{os} with ensure => foo (not a valid value)" do
       let(:params) { {:ensure => 'foo', :object_type => 'foo', :target => '/bar/baz', :order => '10'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['absent', 'present'\]/) }
     end
 
 
     context "#{os} with target => bar/baz (not valid absolute path)" do
       let(:params) { {:object_type => 'foo', :target => 'bar/baz', :order => '10'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -67,7 +73,7 @@ describe('icinga2::object', :type => :define) do
     context "#{os} with template => foo (not a valid boolean)" do
       let(:params) { {:template => 'foo', :object_type => 'foo', :target => '/bar/baz', :order => '10'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
     end
 
 
@@ -103,14 +109,14 @@ describe('icinga2::object', :type => :define) do
     context "#{os} with apply => foo (not valid expression or boolean)" do
       let(:params) { {:apply => 'foo', :apply_target => 'Host', :object_type => 'foo', :target => '/bar/baz', :order => '10'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Boolean or Pattern\[\/\^\.\+\\s\+\(=>\\s\+\.\+\\s\+\)\?in\\s\+\.\+\$\/\]/) }
     end
 
 
     context "#{os} with apply_target => 'foo' (not a valid value)" do
       let(:params) { {:apply_target => 'foo', :object_type => 'foo', :target => '/bar/baz', :order => '10'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['Host', 'Service'\]/) }
     end
 
 
@@ -146,7 +152,7 @@ describe('icinga2::object', :type => :define) do
     context "#{os} with import => foo (not a valid array)" do
       let(:params) { {:import => 'foo', :object_type => 'foo', :target => '/bar/baz', :order => '10'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
     end
 
 
@@ -162,7 +168,7 @@ describe('icinga2::object', :type => :define) do
     context "#{os} with assign => foo (not a valid array)" do
       let(:params) { {:assign => 'foo', :object_type => 'foo', :target => '/bar/baz', :order => '10'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
     end
 
 
@@ -177,7 +183,7 @@ describe('icinga2::object', :type => :define) do
     context "#{os} with ignore => foo (not a valid array)" do
       let(:params) { {:ignore => 'foo', :object_type => 'foo', :target => '/bar/baz', :order => '10'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
     end
 
 
@@ -287,6 +293,12 @@ describe('icinga2::object', :type => :define) do
       "class { 'icinga2': }"
   ] }
 
+	before(:each) do
+		# Fake assert_private function from stdlib to not fail within this test
+		Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) { |args|
+		}
+	end
+
   context "Windows 2012 R2 with all defaults and object_type => foo, target => C:/bar/baz, order => 10" do
     let(:params) { {:object_type => 'foo', :target => 'C:/bar/baz', :order => '10'} }
 
@@ -312,14 +324,14 @@ describe('icinga2::object', :type => :define) do
   context "Windows 2012 R2 with ensure => foo (not a valid value)" do
     let(:params) { {:ensure => 'foo', :object_type => 'foo', :target => 'C:/bar/baz', :order => '10'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['absent', 'present'\]/) }
   end
 
 
   context "Windows 2012 R2 with target => bar/baz (not valid absolute path)" do
     let(:params) { {:object_type => 'foo', :target => 'bar/baz', :order => '10'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -342,7 +354,7 @@ describe('icinga2::object', :type => :define) do
   context "Windows 2012 R2 with template => foo (not a valid boolean)" do
     let(:params) { {:template => 'foo', :object_type => 'foo', :target => 'C:/bar/baz', :order => '10'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a Boolean value/) }
   end
 
 
@@ -378,14 +390,14 @@ describe('icinga2::object', :type => :define) do
   context "Windows 2012 R2 with apply => foo (not valid expression or boolean)" do
     let(:params) { {:apply => 'foo', :apply_target => 'Host', :object_type => 'foo', :target => 'C:/bar/baz', :order => '10'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Boolean or Pattern\[\/\^\.\+\\s\+\(=>\\s\+\.\+\\s\+\)\?in\\s\+\.\+\$\/\]/) }
   end
 
 
   context "Windows 2012 R2 with apply_target => 'foo' (not a valid value)" do
     let(:params) { {:apply_target => 'foo', :object_type => 'foo', :target => 'C:/bar/baz', :order => '10'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['Host', 'Service'\]/) }
   end
 
 
@@ -420,7 +432,7 @@ describe('icinga2::object', :type => :define) do
   context "Windows 2012 R2 with import => foo (not a valid array)" do
     let(:params) { {:import => 'foo', :object_type => 'foo', :target => 'C:/bar/baz', :order => '10'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
   end
 
 
@@ -436,7 +448,7 @@ describe('icinga2::object', :type => :define) do
   context "Windows 2012 R2 with assign => foo (not a valid array)" do
     let(:params) { {:assign => 'foo', :object_type => 'foo', :target => 'C:/bar/baz', :order => '10'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
   end
 
 
@@ -451,7 +463,7 @@ describe('icinga2::object', :type => :define) do
   context "Windows 2012 R2 with ignore => foo (not a valid array)" do
     let(:params) { {:ignore => 'foo', :object_type => 'foo', :target => 'C:/bar/baz', :order => '10'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
   end
 
 

--- a/spec/defines/scheduleddowntime_spec.rb
+++ b/spec/defines/scheduleddowntime_spec.rb
@@ -96,7 +96,7 @@ describe('icinga2::object::scheduleddowntime', :type => :define) do
                       :comment => 'foocomment',
                       :ranges => { 'foo' => "bar", 'bar' => "foo"}} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -133,7 +133,7 @@ describe('icinga2::object::scheduleddowntime', :type => :define) do
                       :comment => 'foocomment',
                       :ranges => { 'foo' => "bar", 'bar' => "foo"}} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\(\\\.\\d\+\)\?\[dhms\]\?\$\/\]/) }
     end
 
 
@@ -155,7 +155,7 @@ describe('icinga2::object::scheduleddowntime', :type => :define) do
                       :author => 'fooauthor',
                       :comment => 'foocomment'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
   end
 end
@@ -270,7 +270,7 @@ describe('icinga2::object::scheduleddowntime', :type => :define) do
                     :comment => 'foocomment',
                     :ranges => { 'foo' => "bar", 'bar' => "foo"}} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -307,7 +307,7 @@ describe('icinga2::object::scheduleddowntime', :type => :define) do
                     :comment => 'foocomment',
                     :ranges => { 'foo' => "bar", 'bar' => "foo"}} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\(\\\.\\d\+\)\?\[dhms\]\?\$\/\]/) }
   end
 
 
@@ -329,6 +329,6 @@ describe('icinga2::object::scheduleddowntime', :type => :define) do
                     :author => 'fooauthor',
                     :comment => 'foocomment'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 end

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -77,7 +77,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
     context "#{os} with vars => { foo => 'bar', bar => 'foo' }" do
@@ -103,7 +103,7 @@ describe('icinga2::object::service', :type => :define) do
 
 
     context "#{os} with max_check_attempts => 30" do
-      let(:params) { {:max_check_attempts => '30', :target => '/bar/baz',
+      let(:params) { {:max_check_attempts => 30, :target => '/bar/baz',
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
@@ -118,7 +118,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
     end
 
 
@@ -145,7 +145,7 @@ describe('icinga2::object::service', :type => :define) do
     context "#{os} with check_interval => foo (not a valid value)" do
       let(:params) { {:check_interval => 'foo', :target => '/bar/baz', :check_command => 'foocommand'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
     end
 
 
@@ -165,7 +165,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
     end
 
 
@@ -185,7 +185,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -205,7 +205,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -225,7 +225,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -245,7 +245,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -265,7 +265,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -285,7 +285,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -301,7 +301,7 @@ describe('icinga2::object::service', :type => :define) do
 
 
     context "#{os} with flapping_threshold => 30" do
-      let(:params) { {:flapping_threshold => '30', :target => '/bar/baz',
+      let(:params) { {:flapping_threshold => 30, :target => '/bar/baz',
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
@@ -316,7 +316,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
     end
 
 
@@ -336,7 +336,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -411,7 +411,7 @@ describe('icinga2::object::service', :type => :define) do
                       :host_name => 'hostfoo',
                       :check_command => 'commandfoo'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -516,7 +516,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
   context "Windows 2012 R2 with vars => { foo => 'bar', bar => 'foo' }" do
@@ -542,7 +542,7 @@ describe('icinga2::object::service', :type => :define) do
 
 
   context "Windows 2012 R2 with max_check_attempts => 30" do
-    let(:params) { {:max_check_attempts => '30', :target => 'C:/bar/baz',
+    let(:params) { {:max_check_attempts => 30, :target => 'C:/bar/baz',
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
@@ -557,7 +557,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 
 
@@ -583,7 +583,7 @@ describe('icinga2::object::service', :type => :define) do
   context "Windows 2012 R2 with check_interval => foo (not a valid value)" do
     let(:params) { {:check_interval => 'foo', :target => 'C:/bar/baz', :check_command => 'foocommand'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
   end
 
 
@@ -603,7 +603,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" does not match/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Pattern\[\/\^\\d\+\\\.\?\\d\*\[d\|h\|m\|s\]\?\$\/\]/) }
   end
 
 
@@ -623,7 +623,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -643,7 +643,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -663,7 +663,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -683,7 +683,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -703,7 +703,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -723,7 +723,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -739,7 +739,7 @@ describe('icinga2::object::service', :type => :define) do
 
 
   context "Windows 2012 R2 with flapping_threshold => 30" do
-    let(:params) { {:flapping_threshold => '30', :target => 'C:/bar/baz',
+    let(:params) { {:flapping_threshold => 30, :target => 'C:/bar/baz',
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
@@ -754,7 +754,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /first argument to be an Integer/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Integer/) }
   end
 
 
@@ -774,7 +774,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -848,7 +848,7 @@ describe('icinga2::object::service', :type => :define) do
                     :host_name => 'hostfoo',
                     :check_command => 'commandfoo'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo\/bar" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 

--- a/spec/defines/servicegroup_spec.rb
+++ b/spec/defines/servicegroup_spec.rb
@@ -57,7 +57,7 @@ describe('icinga2::object::servicegroup', :type => :define) do
     context "#{os} with groups => foo (not a valid array)" do
       let(:params) { {:groups => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
   end
 end
@@ -132,6 +132,6 @@ describe('icinga2::object::servicegroup', :type => :define) do
   context "Windows 2012 R2 with groups => foo (not a valid array)" do
     let(:params) { {:groups => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 end

--- a/spec/defines/timeperiod_spec.rb
+++ b/spec/defines/timeperiod_spec.rb
@@ -57,7 +57,7 @@ describe('icinga2::object::timeperiod', :type => :define) do
     context "#{os} with ranges => 'foo' (not a valid hash)" do
       let(:params) { {:ranges => 'foo', :target => '/bar/baz' } }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
     end
 
 
@@ -73,7 +73,7 @@ describe('icinga2::object::timeperiod', :type => :define) do
     context "#{os} with prefer_includes => foo (not a valid boolean)" do
       let(:params) { {:prefer_includes => 'foo', :target => '/bar/baz', :ranges => { 'foo' => "bar", 'bar' => "foo"}} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -89,7 +89,7 @@ describe('icinga2::object::timeperiod', :type => :define) do
     context "#{os} with excludes => foo (not a valid array)" do
       let(:params) { {:excludes => 'foo', :target => '/bar/baz', :ranges => { 'foo' => "bar", 'bar' => "foo"} }}
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
 
@@ -105,7 +105,7 @@ describe('icinga2::object::timeperiod', :type => :define) do
     context "#{os} with includes => foo (not a valid array)" do
       let(:params) { {:includes => 'foo', :target => '/bar/baz', :ranges => { 'foo' => "bar", 'bar' => "foo"} }}
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
   end
 end
@@ -179,7 +179,7 @@ describe('icinga2::object::TimePeriod', :type => :define) do
   context "Windows 2012 R2 with ranges => 'foo' (not a valid hash)" do
     let(:params) { {:ranges => 'foo', :target => 'C:/bar/baz' } }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a Hash/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Hash/) }
   end
 
 
@@ -195,7 +195,7 @@ describe('icinga2::object::TimePeriod', :type => :define) do
   context "Windows 2012 R2 with prefer_includes => foo (not a valid boolean)" do
     let(:params) { {:prefer_includes => 'foo', :target => 'C:/bar/baz', :ranges => { 'foo' => "bar", 'bar' => "foo"}} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -211,7 +211,7 @@ describe('icinga2::object::TimePeriod', :type => :define) do
   context "Windows 2012 R2 with excludes => foo (not a valid array)" do
     let(:params) { {:excludes => 'foo', :target => 'C:/bar/baz', :ranges => { 'foo' => "bar", 'bar' => "foo"} }}
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 
@@ -227,7 +227,7 @@ describe('icinga2::object::TimePeriod', :type => :define) do
   context "Windows 2012 R2 with includes => foo (not a valid array)" do
     let(:params) { {:includes => 'foo', :target => 'C:/bar/baz', :ranges => { 'foo' => "bar", 'bar' => "foo"} }}
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 end
 

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -85,7 +85,7 @@ describe('icinga2::object::user', :type => :define) do
     context "#{os} with groups => foo (not a valid array)" do
       let(:params) { {:groups => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
 
@@ -101,7 +101,7 @@ describe('icinga2::object::user', :type => :define) do
     context "#{os} with enable_notifications => foo (not a valid boolean)" do
       let(:params) { {:enable_notifications => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
 
 
@@ -126,7 +126,7 @@ describe('icinga2::object::user', :type => :define) do
     context "#{os} with types => foo (not a valid array)" do
       let(:params) { {:types => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
 
@@ -142,7 +142,7 @@ describe('icinga2::object::user', :type => :define) do
     context "#{os} with states => foo (not a valid array)" do
       let(:params) { {:states => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
   end
 end
@@ -244,7 +244,7 @@ describe('icinga2::object::user', :type => :define) do
   context "Windows 2012 R2 with groups => foo (not a valid array)" do
     let(:params) { {:groups => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 
@@ -260,7 +260,7 @@ describe('icinga2::object::user', :type => :define) do
   context "Windows 2012 R2 with enable_notifications => foo (not a valid boolean)" do
     let(:params) { {:enable_notifications => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 
 
@@ -285,7 +285,7 @@ describe('icinga2::object::user', :type => :define) do
   context "Windows 2012 R2 with types => foo (not a valid array)" do
     let(:params) { {:types => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 
@@ -301,7 +301,7 @@ describe('icinga2::object::user', :type => :define) do
   context "Windows 2012 R2 with states => foo (not a valid array)" do
     let(:params) { {:states => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 end

--- a/spec/defines/usergroup_spec.rb
+++ b/spec/defines/usergroup_spec.rb
@@ -57,7 +57,7 @@ describe('icinga2::object::usergroup', :type => :define) do
     context "#{os} with groups => foo (not a valid array)" do
       let(:params) { {:groups => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
     end
 
 
@@ -138,7 +138,7 @@ describe('icinga2::object::usergroup', :type => :define) do
   context "Windows 2012 R2 with groups => foo (not a valid array)" do
     let(:params) { {:groups => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects an Array value/) }
   end
 
 

--- a/spec/defines/zone_spec.rb
+++ b/spec/defines/zone_spec.rb
@@ -35,14 +35,14 @@ describe('icinga2::object::zone', :type => :define) do
     context "#{os} with ensure => foo (not a valid value)" do
       let(:params) { {:ensure => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['absent', 'present'\]/) }
     end
 
 
     context "#{os} with target => bar/baz (not valid absolute path)" do
       let(:params) { {:target => 'bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
     end
 
 
@@ -57,7 +57,7 @@ describe('icinga2::object::zone', :type => :define) do
     context "#{os} with endpoints => foo (not a valid array)" do
       let(:params) { {:endpoints => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
     end
 
 
@@ -80,7 +80,7 @@ describe('icinga2::object::zone', :type => :define) do
     context "#{os} with global => foo (not a valid boolean)" do
       let(:params) { {:global => 'foo', :target => '/bar/baz'} }
 
-      it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+      it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
     end
   end
 end
@@ -131,14 +131,14 @@ describe('icinga2::object::zone', :type => :define) do
   context "Windows 2012 R2 with ensure => foo (not a valid value)" do
     let(:params) { {:ensure => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /foo isn't supported/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Enum\['absent', 'present'\]/) }
   end
 
 
   context "Windows 2012 R2 with target => bar/baz (not valid absolute path)" do
     let(:params) { {:target => 'bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"bar\/baz" is not an absolute path/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a match for Variant\[Stdlib::Windowspath = Pattern\[\/.*\/\], Stdlib::Unixpath = Pattern\[\/.*\/\]\]/) }
   end
 
 
@@ -153,7 +153,7 @@ describe('icinga2::object::zone', :type => :define) do
   context "Windows 2012 R2 with endpoints => foo (not a valid array)" do
     let(:params) { {:endpoints => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not an Array/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Array/) }
   end
 
 
@@ -176,6 +176,6 @@ describe('icinga2::object::zone', :type => :define) do
   context "ws 2012 R2 with global => foo (not a valid boolean)" do
     let(:params) { {:global => 'foo', :target => 'C:/bar/baz'} }
 
-    it { is_expected.to raise_error(Puppet::Error, /"foo" is not a boolean/) }
+    it { is_expected.to raise_error(Puppet::Error, /expects a value of type Undef or Boolean/) }
   end
 end


### PR DESCRIPTION
To drastically improve the performance of this module, all validate_* functions get replaced in this PR with data types. Therefor this PR also drops support for Puppet 3!

Fixes #345