### PR TITLE
Create dependency only to icinga2 packages

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,7 +40,7 @@ class icinga2::repo {
       'debian': {
         # handle icinga stable repo before all package resources
         # contain class problem!
-        Apt::Source['icinga-stable-release'] -> Package <||>
+        Apt::Source['icinga-stable-release'] -> Package <| tag == 'icinga2' |>
         case $::operatingsystem {
           'debian': {
             include ::apt, ::apt::backports


### PR DESCRIPTION
Creating a dependency to `-> Package <||>` is rather unfortunate piece of bad code. It will create a dependency to literally every package in the catalog which is rather inefficient, moreover it can create dependency cycles in case when packages like `apt-transport-https` or [`dirmngr`](https://github.com/puppetlabs/puppetlabs-apt/pull/698) are needed before installing apt sources.

When installing packages Puppet automatically tags with e.g. [module and class name](https://docs.puppet.com/puppet/5.2/lang_tags.html#automatic-tagging). We can use this tags to ensure require dependency only to packages in this module.

