### PR TITLE
fix #378 install package before creating config files

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,6 +19,7 @@ class icinga2::install {
   $package        = $::icinga2::params::package
   $manage_package = $::icinga2::manage_package
   $pki_dir        = $::icinga2::params::pki_dir
+  $conf_dir       = $::icinga2::params::conf_dir
   $user           = $::icinga2::params::user
   $group          = $::icinga2::params::group
 
@@ -27,13 +28,14 @@ class icinga2::install {
 
     package { $package:
       ensure => installed,
-      before => File[$pki_dir],
+      before => File[$pki_dir, $conf_dir],
     }
   }
 
-  file { $pki_dir:
+  file { [$pki_dir, $conf_dir]:
     ensure => directory,
     owner  => $user,
     group  => $group,
   }
 }
+


### PR DESCRIPTION
managing conf_dir (i.e. /etc/icinga2 on Linux) is back again.