### PR TITLE
Remove soft depedencies from metadata.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ monitoring::objects:
     ping4:
       check_command: ping4
       apply: true
-      assign: 
+      assign:
         - host.address
     ssh:
       check_command: ssh

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.16.0 < 5.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.1 < 5.0.0" },
+    { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.1 < 5.0.0" }
   ],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -14,9 +14,6 @@
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.16.0 < 5.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.1 < 5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 < 5.0.0" },
-    { "name": "puppetlabs/chocolatey", "version_requirement": ">= 0.7.0 < 3.0.0" },
-    { "name": "puppet/zypprepo", "version_requirement": ">= 2.0.0 < 3.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Hi,

the puppet styleguide recommends moving soft dependencies out of the metadata.json file. See https://docs.puppet.com/puppet/4.9/style_guide.html#dependencies 

This way I don't get zypprepo and chocolatey installed in a debian-only environment. 

Other projects also apply this 

https://github.com/voxpupuli/puppet-puppetboard/pull/185
https://github.com/theforeman/puppet-puppet/pull/234