### PR TITLE
Support manage_repo on XenServer

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -23,7 +23,7 @@ class icinga2::repo {
     case $::osfamily {
       'redhat': {
         case $::operatingsystem {
-          'centos', 'redhat', 'oraclelinux', 'cloudlinux': {
+          'centos', 'redhat', 'oraclelinux', 'cloudlinux', 'xenserver': {
             yumrepo { 'icinga-stable-release':
               baseurl  => "http://packages.icinga.com/epel/${::operatingsystemmajrelease}/release/",
               descr    => 'ICINGA (stable release for epel)',


### PR DESCRIPTION
XenServer is an Citrix appliance based on CentOS 7. Tested to work.