### PR TITLE
Add support for SLC6 Linux

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -23,7 +23,7 @@ class icinga2::repo {
     case $::osfamily {
       'redhat': {
         case $::operatingsystem {
-          'centos', 'redhat', 'oraclelinux', 'cloudlinux', 'xenserver': {
+          'centos', 'redhat', 'oraclelinux', 'cloudlinux', 'xenserver', 'slc': {
             yumrepo { 'icinga-stable-release':
               baseurl  => "http://packages.icinga.com/epel/${::operatingsystemmajrelease}/release/",
               descr    => 'ICINGA (stable release for epel)',


### PR DESCRIPTION
Hi,
Scientific Linux Cern 6 is a CentOs6 fork. This project has split to Scientific Linux 7 and Cern CentOs 7.
Since SLC6 is a CentOs6 fork, the repository works for it as well.
With the added, we can use the module for SLC6 as well.