### PR TITLE
437 windows ownergroup

### DIFF
--- a/manifests/config/fragment.pp
+++ b/manifests/config/fragment.pp
@@ -28,8 +28,8 @@ define icinga2::config::fragment(
   case $::osfamily {
     'windows': {
       Concat {
-        owner => 'Administrators',
-        group => 'NETWORK SERVICE',
+        owner => $::icinga2::user,
+        group => $::icinga2::group,
         mode  => '0770',
       }
       $_content = regsubst($content, '\n', "\r\n", 'EMG')

--- a/manifests/config/fragment.pp
+++ b/manifests/config/fragment.pp
@@ -28,8 +28,8 @@ define icinga2::config::fragment(
   case $::osfamily {
     'windows': {
       Concat {
-        owner => 'Administrators',
-        group => 'NETWORK SERVICE',
+        owner => $::icinga2::params::user,
+        group => $::icinga2::params::group,
         mode  => '0770',
       }
       $_content = regsubst($content, '\n', "\r\n", 'EMG')

--- a/manifests/feature.pp
+++ b/manifests/feature.pp
@@ -13,8 +13,8 @@ define icinga2::feature(
   validate_re($ensure, [ '^present$', '^absent$' ],
     "${ensure} isn't supported. Valid values are 'present' and 'absent'.")
 
-  $user     = $::icinga2::params::user
-  $group    = $::icinga2::params::group
+  $user     = $::icinga2::user
+  $group    = $::icinga2::group
   $conf_dir = $::icinga2::params::conf_dir
 
   if $::osfamily != 'windows' {

--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -175,8 +175,8 @@ class icinga2::feature::api(
   $conf_dir      = $::icinga2::params::conf_dir
   $pki_dir       = $::icinga2::params::pki_dir
   $ca_dir        = $::icinga2::params::ca_dir
-  $user          = $::icinga2::params::user
-  $group         = $::icinga2::params::group
+  $user          = $::icinga2::user
+  $group         = $::icinga2::group
   $node_name     = $::icinga2::_constants['NodeName']
   $_ssl_key_mode = $::osfamily ? {
     'windows' => undef,

--- a/manifests/feature/idomysql.pp
+++ b/manifests/feature/idomysql.pp
@@ -153,8 +153,8 @@ class icinga2::feature::idomysql(
     fail('You must include the icinga2 base class before using any icinga2 feature class!')
   }
 
-  $owner                = $::icinga2::params::user
-  $group                = $::icinga2::params::group
+  $owner                = $::icinga2::user
+  $group                = $::icinga2::group
   $node_name            = $::icinga2::_constants['NodeName']
   $conf_dir             = $::icinga2::params::conf_dir
   $ssl_dir              = "${::icinga2::params::pki_dir}/ido-mysql"

--- a/manifests/feature/influxdb.pp
+++ b/manifests/feature/influxdb.pp
@@ -125,8 +125,8 @@ class icinga2::feature::influxdb(
     fail('You must include the icinga2 base class before using any icinga2 feature class!')
   }
 
-  $user          = $::icinga2::params::user
-  $group         = $::icinga2::params::group
+  $user          = $::icinga2::user
+  $group         = $::icinga2::group
   $node_name     = $::icinga2::_constants['NodeName']
   $conf_dir      = $::icinga2::params::conf_dir
   $ssl_dir       = "${::icinga2::params::pki_dir}/influxdb"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,14 @@
 #   `repository.d` is removed since Icinga 2 2.8.0, set to true (default) will handle the directory.
 #   This Parameter will change to false by default in v2.0.0 and will be removed in the future.
 #
+# [*user*]
+#   User is set by default for each OS in params.pp, but, with some localized 
+#   version of OS you can specify another user
+#
+# [*group*]
+#   Group is set by default for each OS in params.pp, but, with some localized 
+#   version of OS you may have to specify another group.
+#
 # All default parameters are set in the icinga2::params class. To get more technical information have a look into the
 # params.pp manifest.
 #
@@ -139,6 +147,17 @@
 #     ...
 #     confd => 'local.d',
 #   }
+#  
+# To manage a French windows agent 
+# 
+# class { '::icinga2':
+#     manage_repo    => false,
+#     manage_package => false,
+#     confd          => false,
+#     user           => 'Administrateurs',
+#     group          => 'Service Réseau',
+#     features       => [ 'checker','mainlog' ],
+# }
 #
 #
 class icinga2(
@@ -153,6 +172,8 @@ class icinga2(
   $plugins        = $icinga2::params::plugins,
   $confd          = true,
   $repositoryd    = true,
+  $user           = $icinga2::params::user,
+  $group          = $icinga2::params::group,
 ) inherits ::icinga2::params {
 
   validate_re($ensure, [ '^running$', '^stopped$' ],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,8 +20,8 @@ class icinga2::install {
   $manage_package = $::icinga2::manage_package
   $pki_dir        = $::icinga2::params::pki_dir
   $conf_dir       = $::icinga2::params::conf_dir
-  $user           = $::icinga2::params::user
-  $group          = $::icinga2::params::group
+  $user           = $::icinga2::user
+  $group          = $::icinga2::group
   $repositoryd    = $::icinga2::repositoryd
 
   if $manage_package {

--- a/manifests/object.pp
+++ b/manifests/object.pp
@@ -84,8 +84,8 @@ define icinga2::object(
   case $::osfamily {
     'windows': {
       Concat {
-        owner => 'Administrators',
-        group => 'NETWORK SERVICE',
+        owner => $::icinga2::params::user,
+        group => $::icinga2::params::group,
         mode  => '0770',
       }
     } # windows

--- a/manifests/object.pp
+++ b/manifests/object.pp
@@ -84,8 +84,8 @@ define icinga2::object(
   case $::osfamily {
     'windows': {
       Concat {
-        owner => 'Administrators',
-        group => 'NETWORK SERVICE',
+        owner => $::icinga2::user,
+        group => $::icinga2::group,
         mode  => '0770',
       }
     } # windows

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -142,8 +142,8 @@ class icinga2::params {
     } # Linux
 
     'windows': {
-      $user                 = undef
-      $group                = undef
+      $user                 = 'Administrators'
+      $group                = 'NETWORK SERVICE'
       $icinga2_bin          = 'icinga2.exe'
       $bin_dir              = 'C:/Program Files/icinga2/sbin'
       $conf_dir             = 'C:/ProgramData/icinga2/etc/icinga2'

--- a/manifests/pki/ca.pp
+++ b/manifests/pki/ca.pp
@@ -67,8 +67,8 @@ class icinga2::pki::ca(
   $bin_dir   = $::icinga2::params::bin_dir
   $ca_dir    = $::icinga2::params::ca_dir
   $pki_dir   = $::icinga2::params::pki_dir
-  $user      = $::icinga2::params::user
-  $group     = $::icinga2::params::group
+  $user      = $::icinga2::user
+  $group     = $::icinga2::group
   $node_name = $::icinga2::_constants['NodeName']
 
   File {


### PR DESCRIPTION
Hi,

This PR address localized windows server problem.
It works fine to install and maintain rights owner/group on windows and does not change behaviour on linux.

To manage a French windows agent : 
```
class { '::icinga2':
    manage_repo    => false,
    manage_package => false,
    confd          => false,
    user           => 'Administrateurs',
    group          => 'Service Réseau',
    features       => [ 'checker','mainlog' ],
}
```

It may works for any other language.
Regards,
