### PR TITLE
Depend on Apt::Update instead of Apt::Source

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,7 +40,9 @@ class icinga2::repo {
       'debian': {
         # handle icinga stable repo before all package resources
         # contain class problem!
-        Apt::Source['icinga-stable-release'] -> Package <| tag == 'icinga2' |>
+        Apt::Source['icinga-stable-release'] -> Class['icinga2::install']
+        Class['apt::update'] -> Class['icinga2::install']
+
         case $::operatingsystem {
           'debian': {
             include ::apt, ::apt::backports
@@ -71,7 +73,6 @@ class icinga2::repo {
             fail('Your plattform is not supported to manage a repository.')
           }
         }
-        contain ::apt::update
       }
       'suse': {
 


### PR DESCRIPTION
Hi,

i would like to change the dependency from Apt::Source to Class['Apt::Update']

puppetlabs-apt handle the apt::update well, if a new Apt::Source has changed, Apt::Update gets an notify.

Why is it a problem?

Newer systems like Debian 9 require a new package to handle apt-key: `dirmgmr`. https://github.com/puppetlabs/puppetlabs-apt/blob/master/manifests/init.pp#L187

Since you include apt from your class, the `Package['dirmgmr']` package will get the tag `icinga2`, too.

It is in a conflict with your dependency

https://github.com/Icinga/puppet-icinga2/blob/0e21436a051f6e42dd6406fe5c540333daa75521/manifests/repo.pp#L43

because die `Package['dirmgmr']` is required to add the `Apt::Source`.

An alternate solution would be to change the dependency to
```
Apt::Source['icinga-stable-release'] -> Class['icinga2::install']
```