### PR TITLE
Quote and escape string values correctly

### DIFF
--- a/lib/puppet_x/icinga2/utils.rb
+++ b/lib/puppet_x/icinga2/utils.rb
@@ -92,7 +92,7 @@ module Puppet
             if $constants.index { |x| if $hash_attrs.include?(x) then value =~ /^!?(#{x})(\..+$|$)/ else value =~ /^!?#{x}$/ end }
               result = value
             else
-              result = "\"#{value}\""
+              result = value.dump
             end
           end
 


### PR DESCRIPTION
Something like `^blah\.example\.com/blah$$` in a vars value for
example was not escaped and ended up directly in the config, which
is not valid. It should be (and now is with this change) escaped to
this in the config `"^blah\\.example\\.com/blah$$"`.