### PR TITLE
Fixed requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ available in Icinga 2 can be enabled and configured with this module.
 
 This module depends on:
 
-* [puppetlabs/stdlib] >= 4.16.0
-* [puppetlabs/concat] >= 2.1.0
+* [puppetlabs/stdlib] >= 4.16.0 < 5.0.0
+* [puppetlabs/concat] >= 2.1.0 < 5.0.0
 
 Depending on your setup following modules may also be required:
 


### PR DESCRIPTION
Without the upper limit people will wonder why dependencies are not met when trying to install.