### PR TITLE
Quoting mistake in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ icinga2::object::hostgroup { 'monitoring-hosts':
   display_name => 'Linux Servers',
   groups       => [ 'linux-servers' ],
   target       => '/etc/icinga2/conf.d/groups2.conf',
-  assign       => [ 'host.vars.os == "linux"' ],
+  assign       => [ 'host.vars.os == linux' ],
 }
 ```
 


### PR DESCRIPTION
`"linux"` would be parsed to `""linux""` and result in an error because this is not valid for icinga.