### PR TITLE
Always set the API cert paths

### DIFF
--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -291,6 +291,9 @@ class icinga2::feature::api(
 
   # compose attributes
   $attrs = {
+    cert_path                        => $_ssl_cert_path,
+    key_path                         => $_ssl_key_path,
+    ca_path                          => $_ssl_cacert_path,
     crl_path                         => $ssl_crl,
     accept_commands                  => $accept_commands,
     accept_config                    => $accept_config,


### PR DESCRIPTION
Since 53e9e29f2dd4a422fd5d1708ed2238e7703dbf52 these paths are not set anymore. With the Icinga 2 version included in Debian Stretch this results in an error and the service refuses to start up. This patch explicitly sets these values again.