### PR TITLE
Set the object file owner to root

### DIFF
--- a/manifests/object.pp
+++ b/manifests/object.pp
@@ -84,7 +84,7 @@ define icinga2::object(
     } # windows
     default: {
       Concat {
-        owner => $::icinga2::globals::user,
+        owner => 'root',
         group => $::icinga2::globals::group,
         mode  => '0640',
       }


### PR DESCRIPTION
Icinga shouldn't modify these files since Puppet managed them. It can already read the via the group.