### PR TITLE
Allow using a relative object target

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,6 +165,12 @@ class icinga2 (
     $_confd = $confd
   }
 
+  $confd_path = $_confd ? {
+    Stdlib::Absolutepath => $_confd,
+    String               => "${::icinga2::globals::conf_dir}/${_confd}",
+    default              => undef,
+  }
+
   Class['::icinga2::config']
   -> Concat <| tag == 'icinga2::config::file' |>
   ~> Class['::icinga2::service']

--- a/spec/defines/objects_spec.rb
+++ b/spec/defines/objects_spec.rb
@@ -74,6 +74,42 @@ describe('icinga2::object', :type => :define) do
     facts
   end
 
+  context 'with relative target' do
+    let(:params) do
+      {
+        :object_type => 'foobar',
+        :target      => 'bar.conf',
+        :order       => '10'
+      }
+    end
+
+    context 'with confd => true' do
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'icinga2':
+          confd => true,
+        }
+        PUPPET
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_concat__fragment('foo')
+        .with_target('/etc/icinga2/conf.d/bar.conf') }
+    end
+
+    context 'with confd => false' do
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'icinga2':
+          confd => false,
+        }
+        PUPPET
+      end
+
+      it { is_expected.to raise_error(/Target must be absolute if no confd directory is set/) }
+    end
+  end
+
   context "with template => true" do
     let(:params) do
       {


### PR DESCRIPTION
This uses the confd directory from the main class if the object's target is relative. All the old behavior is preserved if the path is absolute.  When there is no confd directory it hard fails. Since the config wouldn't be loaded anyway, this makes the most sense.