### PR TITLE
Fix Puppet4 build

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,8 +1,9 @@
 --relative
 --no-80chars-check
 --no-140chars-check
---fail_on_warnings
 --no-only_variable_string-check
 --no-class_inherits_from_params_class-check
 #obsololete?
 #--log-format '%{path}:%{line}:%{check}:%{KIND}:%{message}'
+# fix puppet4 build
+#--fail_on_warnings


### PR DESCRIPTION
removed fail on warnings from .puppet-lint.rc file to fix Puppet 4.10/Ruby 2.1.9 build