### PR TITLE
Add constants for Gentoo AMD64

### DIFF
--- a/data/Gentoo-amd64-family.yaml
+++ b/data/Gentoo-amd64-family.yaml
@@ -1,0 +1,6 @@
+---
+icinga2::globals::constants:
+  PluginDir: /usr/lib64/nagios/plugins
+  PluginContribDir: /usr/lib64/nagios/plugins
+  ManubulonPluginDir: /usr/lib64/nagios/plugins
+icinga2::globals::lib_dir: /usr/lib64


### PR DESCRIPTION
On AMD64 /usr/lib was a symlink to /usr/lib64 but with the 17.1 profile /usr/lib contains the 32 bit content while the plugins were always in /usr/lib64. That means this change is safe for both profiles, but required for the new profile that was just stablized.