### PR TITLE
Influxdb can be reachable via any port

### DIFF
--- a/manifests/feature/influxdb.pp
+++ b/manifests/feature/influxdb.pp
@@ -94,7 +94,7 @@
 class icinga2::feature::influxdb(
   Enum['absent', 'present']                $ensure                 = present,
   Optional[Stdlib::Host]                   $host                   = undef,
-  Optional[Stdlib::Port::Unprivileged]     $port                   = undef,
+  Optional[Stdlib::Port]                   $port                   = undef,
   Optional[String]                         $database               = undef,
   Optional[String]                         $username               = undef,
   Optional[String]                         $password               = undef,


### PR DESCRIPTION
I see no reasen why Influxdb should only allow highports. For example my setup where I have my Influxdb reachable via a reversproxy on port 443.