### PR TITLE
rework icinga2::repo class to a public class

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,18 +169,11 @@ You can also change or set every other parameter of the underlying resources, su
     * a workaround is implemented to use a parameter proxy also to download the gpg key thru a proxy, see https://github.com/Icinga/puppet-icinga2/issues/397.
 
 If you want to manage the version of Icinga 2, you have to disable the package management of this module and handle
-packages in your own Puppet code. The attribute manage_repo is also disabled automattically and you have to manage
-a repository within icinga in front of the package resource, i.e. for a RedHat system:
+packages in your own Puppet code. The attribute manage_repo is disabled by default and you have to manage
+a repository within icinga in front of the package resource. You can combine this one with the section before about repositories.
 
 ``` puppet
-yumrepo { 'icinga-stable-release':
-  baseurl  => "http://packages.icinga.com/epel/${::operatingsystemmajrelease}/release/",
-  descr    => 'ICINGA (stable release for epel)',
-  enabled  => 1,
-  gpgcheck => 1,
-  gpgkey   => 'http://packages.icinga.com/icinga.key',
-  before   => Package['icinga2'],
-}
+include ::icinga2::repo
 
 package { 'icinga2':
   ensure => latest,

--- a/examples/init_package.pp
+++ b/examples/init_package.pp
@@ -1,7 +1,10 @@
+include ::icinga2::repo
+
 package { 'icinga2':
   ensure => latest,
+  notify => Class['icinga2'],
 }
-~>
+
 class { '::icinga2':
   manage_package => false,
 }

--- a/examples/init_package_idomysql.pp
+++ b/examples/init_package_idomysql.pp
@@ -1,7 +1,10 @@
+include ::icinga2::repo
+
 package { ['icinga2', 'icinga2-ido-mysql']:
   ensure => latest,
+  notify => Class['icinga2'],
 }
-~>
+
 class { 'icinga2':
   manage_package => false,
 }

--- a/examples/init_package_idopgsql.pp
+++ b/examples/init_package_idopgsql.pp
@@ -1,7 +1,10 @@
+include ::icinga2::repo
+
 package { ['icinga2', 'icinga2-ido-pgsql']:
   ensure => latest,
+  notify => Class['icinga2'],
 }
-~>
+
 class{ 'icinga2':
   manage_package => false,
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -170,7 +170,10 @@ class icinga2 (
   ~> Class['::icinga2::service']
 
   # Put ::icinga2::repo outside to work around dependency cycle issues with the apt module
-  include '::icinga2::repo'
+  # and to use this class independently.
+  if $::icinga2::manage_repo {
+    include '::icinga2::repo'
+  }
 
   anchor { '::icinga2::begin':
     notify => Class['::icinga2::service'],

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,69 +16,62 @@
 #
 class icinga2::repo {
 
-  assert_private()
+  $repo =  lookup('icinga2::repo', Hash, 'deep', {})
 
-  if $::icinga2::manage_repo and $::icinga2::manage_package {
-
-    $repo =  lookup('icinga2::repo', Hash, 'deep', {})
-
-    case $::osfamily {
-      'redhat': {
-        yumrepo { 'icinga-stable-release':
-          * => $repo,
-        }
-        Yumrepo['icinga-stable-release'] -> Package<|tag == 'icinga2'|>
+  case $::osfamily {
+    'redhat': {
+      yumrepo { 'icinga-stable-release':
+        * => $repo,
       }
+      Yumrepo['icinga-stable-release'] -> Package<|tag == 'icinga2'|>
+    }
 
-      'debian': {
-        # handle icinga stable repo before all package resources
-        # contain class problem!
-        Apt::Source['icinga-stable-release'] -> Package <| tag == 'icinga2' |>
-        Class['Apt::Update'] -> Package<|tag == 'icinga2'|>
+    'debian': {
+      # handle icinga stable repo before all package resources
+      # contain class problem!
+      Apt::Source['icinga-stable-release'] -> Package <| tag == 'icinga2' |>
+      Class['Apt::Update'] -> Package<|tag == 'icinga2'|>
 
-        contain ::apt, ::apt::backports
+      contain ::apt, ::apt::backports
 
-        apt::source { 'icinga-stable-release':
-          * => $repo,
-        }
-      }
-
-      'suse': {
-
-        Zypprepo['icinga-stable-release'] -> Package <| tag == 'icinga2' |>
-
-        if $repo['proxy'] {
-          $_proxy = "--httpproxy ${repo['proxy']}"
-        } else {
-          $_proxy = undef
-        }
-
-        exec { 'import icinga gpg key':
-          path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-          command   => "rpm ${_proxy} --import ${repo['gpgkey']}",
-          unless    => 'rpm -q gpg-pubkey-34410682',
-          logoutput => 'on_failure',
-        }
-
-        -> zypprepo { 'icinga-stable-release':
-          * => delete($repo, 'proxy'),
-        }
-
-        -> file_line { 'add proxy settings to icinga repo':
-          path => '/etc/zypp/repos.d/icinga-stable-release.repo',
-          line => "proxy=${repo['proxy']}",
-        }
-      }
-
-      'windows': {
-        warning("The Icinga Project doesn't offer chocolaty packages at the moment.")
-      }
-
-      default: {
-        fail('Your plattform is not supported to manage a repository.')
+      apt::source { 'icinga-stable-release':
+        * => $repo,
       }
     }
 
-  } # if $::icinga::manage_repo
+    'suse': {
+      Zypprepo['icinga-stable-release'] -> Package <| tag == 'icinga2' |>
+
+      if $repo['proxy'] {
+        $_proxy = "--httpproxy ${repo['proxy']}"
+      } else {
+        $_proxy = undef
+      }
+
+      exec { 'import icinga gpg key':
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        command   => "rpm ${_proxy} --import ${repo['gpgkey']}",
+        unless    => 'rpm -q gpg-pubkey-34410682',
+        logoutput => 'on_failure',
+      }
+
+      -> zypprepo { 'icinga-stable-release':
+        * => delete($repo, 'proxy'),
+      }
+
+      -> file_line { 'add proxy settings to icinga repo':
+        path => '/etc/zypp/repos.d/icinga-stable-release.repo',
+        line => "proxy=${repo['proxy']}",
+      }
+    }
+
+    'windows': {
+      warning("The Icinga Project doesn't offer chocolaty packages at the moment.")
+    }
+
+    default: {
+      fail('Your plattform is not supported to manage a repository.')
+    }
+  } # osfamily
 
 }


### PR DESCRIPTION
to use in front of other classes or resources like:

include ::icinga2::repo

package { 'icinga2':
  ensure => latest,
  notify => Class['icinga2'],
}

class { '::icinga2':
  manage_package => false,
}

Then the use of hiera for own repos are also possible.