### PR TITLE
Managing CA directory with known certificates

### DIFF
--- a/manifests/pki/ca.pp
+++ b/manifests/pki/ca.pp
@@ -21,8 +21,8 @@
 #   Content of the CA key. If this is unset, a key will be generated with the Icinga 2 CLI.
 #
 class icinga2::pki::ca(
-  $ca_cert         = undef,
-  $ca_key          = undef,
+  Optional[String]               $ca_cert         = undef,
+  Optional[String]               $ca_key          = undef,
 ) {
 
   require ::icinga2::config

--- a/manifests/pki/ca.pp
+++ b/manifests/pki/ca.pp
@@ -21,8 +21,8 @@
 #   Content of the CA key. If this is unset, a key will be generated with the Icinga 2 CLI.
 #
 class icinga2::pki::ca(
-  Optional[String]               $ca_cert         = undef,
-  Optional[String]               $ca_key          = undef,
+  $ca_cert         = undef,
+  $ca_key          = undef,
 ) {
 
   require ::icinga2::config
@@ -68,11 +68,16 @@ class icinga2::pki::ca(
       $_ca_key      = $ca_key
     }
 
+    file { "${ca_dir}":
+      ensure  => directory,
+    }
+
     file { "${ca_dir}/ca.crt":
       ensure  => file,
       content => $_ca_cert,
       tag     => 'icinga2::config::file',
       before  => File[$_ssl_cacert_path],
+      require => File[$ca_dir],
     }
 
     file { "${ca_dir}/ca.key":
@@ -82,6 +87,7 @@ class icinga2::pki::ca(
       tag       => 'icinga2::config::file',
       show_diff => false,
       backup    => false,
+      require => File[$ca_dir],
     }
   }
 


### PR DESCRIPTION
When creating an icinga master, but instead of letting icinga create its ca certificates, force the use of the certificates via hieradata, the ca.crt and ca.key can not be created unless the ${ca_dir} is created.
This PR allows declaring the ${ca_dir} on the ca module; so you can choose
1) Not to set ca certificates, hence letting the module create new the new ca or
2) Set ca certificates, hence creating the ca with the content passed via hiera to the module
icinga2::pki::ca::ca_cert
icinga2::pki::ca::ca_key