### PR TITLE
Missing parameters

### DIFF
--- a/data/FreeBSD-kernel.yaml
+++ b/data/FreeBSD-kernel.yaml
@@ -15,3 +15,6 @@ icinga2::globals::spool_dir: /var/spool/icinga2
 icinga2::globals::cache_dir: /var/cache/icinga2
 icinga2::globals::cert_dir: /var/lib/icinga2/certs
 icinga2::globals::ca_dir: /var/lib/icinga2/ca
+icinga2::globals::constants:
+  PluginDir: '/usr/local/libexec/nagios'
+  PluginContribDir: '/usr/local/libexec/nagios'


### PR DESCRIPTION
  Without this parameter the module don't work under FreeBSD, the file
  'constants.conf' created by the module don't get the PluginDir, but
  the standard config for the plugin still get thing like

        command = [ PluginDir + "/check_ping" ]

  so icinga2 won't start because PluginDir are unkown