### PR TITLE
Accepts SHA1 and SHA256 fingerprint digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ class { '::icinga2::feature::api':
   ca_host         => '172.16.1.11',
   ticket_salt     => '5a3d695b8aef8f18452fc494593056a4',
   # to increase your security set fingerprint to validate the certificate of ca_host
-  # fingerprint     => 'D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:50:68:01:99:3D:96:72:72',
+  # fingerprint     => 'D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:50:68:01:D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:99:3D:96:72:72',
   endpoints       => {
     'satellite.example.org' => {},
     'master.example.org'    => {
@@ -292,7 +292,7 @@ class { '::icinga2::feature::api':
   accept_commands => true,
   ticket_salt     => '5a3d695b8aef8f18452fc494593056a4',
   # to increase your security set fingerprint to validate the certificate of ca_host
-  # fingerprint     => 'D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:50:68:01:99:3D:96:72:72',
+  # fingerprint     => 'D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:50:68:01:D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:99:3D:96:72:72',
   endpoints       => {
     'NodeName'              => {},
     'satellite.example.org' => {
@@ -316,7 +316,7 @@ icinga2::object::zone { 'global-templates':
 ```
 
 The parameter `fingerprint` is optional and new since v2.1.0. It's used to validate the certificate of the CA host.
-A fingerprint can be got by `openssl x509 -noout -fingerprint -sha1 -inform pem -in master.crt` on the master host.
+You can get the fingerprint via `openssl x509 -noout -fingerprint -sha256 -inform pem -in master.crt` on the master host. (Icinga2 versions before 2.12.0 require '-sha1' as digest algorithm.)
 
 
 ### Config Objects

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -459,8 +459,8 @@ Default value: 5665
 Data type: `Optional[Icinga2::Fingerprint]`
 
 Fingerprint of the CA host certificate for validation. Requires pki is set to `icinga2`.
-You can get the fingerprint via 'openssl x509 -noout -fingerprint -sha1 -inform pem -in [certificate-file.crt]'
-on your CA host.
+You can get the fingerprint via 'openssl x509 -noout -fingerprint -sha256 -inform pem -in [certificate-file.crt]'
+on your CA host. (Icinga2 versions before 2.12.0 require '-sha1' as digest algorithm.)
 
 Default value: `undef`
 
@@ -4282,7 +4282,7 @@ Alias of `Optional[Variant[String, Array[Variant[String, Hash]], Hash]]`
 
 Type for certificate fingerprints
 
-Alias of `Pattern[/^([0-9a-fA-F]{2}\:){19}[0-9,a-f,A-F]{2}$/]`
+Alias of `Pattern[/^([0-9a-fA-F]{2}\:)({19}[0-9a-fA-F]{2}\:){12})?[0-9,a-f,A-F]{2}$/]`
 
 ### Icinga2::Interval
 

--- a/examples/init_slave_validate.pp
+++ b/examples/init_slave_validate.pp
@@ -7,8 +7,8 @@ case $::osfamily {
 $master_cert = 'master.localdomain'
 $master_ip   = '192.168.5.12'
 
-# get it on CA host 'openssl x509 -noout -fingerprint -sha1 -inform pem -in /var/lib/icinga2/certs/master.localdomain.crt'
-$fingerprint = 'D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:50:68:01:99:3D:96:72:72'
+# get it on CA host 'openssl x509 -noout -fingerprint -sha256 -inform pem -in /var/lib/icinga2/certs/master.localdomain.crt'
+$fingerprint = 'D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:50:68:01:D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:99:3D:96:72:72'
 
 class { '::icinga2':
   manage_repo  => true,

--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -95,8 +95,8 @@
 #
 # @param [Optional[Icinga2::Fingerprint]] fingerprint
 #   Fingerprint of the CA host certificate for validation. Requires pki is set to `icinga2`.
-#   You can get the fingerprint via 'openssl x509 -noout -fingerprint -sha1 -inform pem -in [certificate-file.crt]'
-#   on your CA host.
+#   You can get the fingerprint via 'openssl x509 -noout -fingerprint -sha256 -inform pem -in [certificate-file.crt]'
+#   on your CA host. (Icinga2 versions before 2.12.0 require '-sha1' as digest algorithm.)
 # 
 # @param [String] ticket_salt
 #   Salt to use for ticket generation. The salt is stored to api.conf if none or ca is chosen for pki.

--- a/types/fingerprint.pp
+++ b/types/fingerprint.pp
@@ -1,2 +1,4 @@
 # Type for certificate fingerprints
-type Icinga2::Fingerprint = Pattern[/^([0-9a-fA-F]{2}\:){19}[0-9,a-f,A-F]{2}$/]
+# SHA1: 160 bit (20 byte) digest
+# SHA256: 256 bit (32 byte) digest
+type Icinga2::Fingerprint = Pattern[/^([0-9a-fA-F]{2}\:){19}(([0-9a-fA-F]{2}\:){12})?[0-9,a-f,A-F]{2}$/]


### PR DESCRIPTION
The hash algorithm was changed from SHA1 to SHA256 with Icinga2 release
2.12.0. The type definition must accept both variants.

Fixes #631 