### PR TITLE
Add new param manage_repos to replace manage_repo in the future

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Markus Frosch <markus.frosch@icinga.com>
 Matthias Baur <m.baur@syseleven.de>
 Matthias Ritter <matthias.ritter@dm.de>
 Michael Friedrich <michael.friedrich@icinga.com>
+Ott, Jörn WI (Fa. Allgeier Experts / Goetzfried) <Joern.Ott@schufa.de>
 Philipp Dallig <philipp.dallig@gmail.com>
 Rowan Ruseler <rowanruseler@gmail.com>
 Rudy Gevaert <rudy.gevaert@ugent.be>
@@ -29,11 +30,13 @@ Simon Hoenscheid <sh@example42.com>
 Stefan Kleindl <stefan.kleindl@rise-world.com>
 Thomas Dalichow <thomas.dalichow@publicispixelpark.de>
 Thomas Gelf <thomas@gelf.net>
+Thorsten Kahler <kahler@hrz.uni-marburg.de>
 Till Adam <till.adam@dm.de>
 Tim Meusel <tim@bastelfreak.de>
 Tom De Vylder <tom@penumbra.be>
 Tomas Barton <barton.tomas@gmail.com>
 Wyatt Alt <wyatt.alt@gmail.com>
 Zach Leslie <xaque208@gmail.com>
+jas01 <Through github>
 murmur <hristo.mohamed@gmail.com>
 paladox <paladox@users.noreply.github.com>

--- a/examples/example2/hieradata/nodes/agent.local.yaml
+++ b/examples/example2/hieradata/nodes/agent.local.yaml
@@ -1,5 +1,5 @@
 ---
-icinga2::manage_repo: true
+icinga2::manage_repos: true
 icinga2::confd: false
 icinga2::features:
   - 'api'

--- a/examples/example2/hieradata/nodes/master.local.yaml
+++ b/examples/example2/hieradata/nodes/master.local.yaml
@@ -1,5 +1,5 @@
 ---
-icinga2::manage_repo: true
+icinga2::manage_repos: true
 icinga2::confd: false
 icinga2::features:
   - 'api'

--- a/examples/example2/hieradata/nodes/satellite.local.yaml
+++ b/examples/example2/hieradata/nodes/satellite.local.yaml
@@ -1,5 +1,5 @@
 ---
-icinga2::manage_repo: true
+icinga2::manage_repos: true
 icinga2::confd: false
 icinga2::features:
   - 'api'

--- a/examples/example3/hieradata/nodes/icingamaster.yaml
+++ b/examples/example3/hieradata/nodes/icingamaster.yaml
@@ -1,5 +1,5 @@
 ---
-icinga2::manage_repo: true
+icinga2::manage_repos: true
 icinga2::confd: true
 icinga2::constants:
   NodeName: "%{::fqdn}"

--- a/examples/example3/site/profile/manifests/icinga/agent.pp
+++ b/examples/example3/site/profile/manifests/icinga/agent.pp
@@ -11,9 +11,9 @@ class profile::icinga::agent {
 
     # Options valid for all agents, thus defined inside the manifest
     class { '::icinga2':
-        manage_repo => true,
-        confd       => false,
-        features    => [ 'mainlog' ],
+        manage_repos => true,
+        confd        => false,
+        features     => [ 'mainlog' ],
     }
 
     # Leave this here or put it in a yaml file common

--- a/examples/example4/profile/manifests/agent.pp
+++ b/examples/example4/profile/manifests/agent.pp
@@ -14,9 +14,9 @@ class profile::icinga2::agent(
   }
 
   class { '::icinga2':
-    manage_repo => true,
-    confd       => false,
-    features    => ['mainlog'],
+    manage_repos => true,
+    confd        => false,
+    features     => ['mainlog'],
   }
 
   # Feature: api

--- a/examples/example4/profile/manifests/master.pp
+++ b/examples/example4/profile/manifests/master.pp
@@ -9,7 +9,7 @@ class profile::icinga2::master {
   }
 
   class { '::icinga2':
-    manage_repo    => true,
+    manage_repos   => true,
     purge_features => false,
     confd          => false,
     constants      => {

--- a/examples/example4/profile/manifests/slave.pp
+++ b/examples/example4/profile/manifests/slave.pp
@@ -15,10 +15,10 @@ class profile::icinga2::slave(
   }
 
   class { '::icinga2':
-    manage_repo => true,
-    confd       => false,
-    features    => ['checker','mainlog'],
-    constants   => {
+    manage_repos => true,
+    confd        => false,
+    features     => ['checker','mainlog'],
+    constants    => {
       'ZoneName' => $slave_zone,
     },
   }

--- a/examples/example_config.pp
+++ b/examples/example_config.pp
@@ -1,6 +1,6 @@
 class { '::icinga2':
-  manage_repo => true,
-  confd       => 'example.d',
+  manage_repos => true,
+  confd        => 'example.d',
 }
 
 file { '/etc/icinga2/example.d':

--- a/examples/example_service_mysql.pp
+++ b/examples/example_service_mysql.pp
@@ -23,8 +23,8 @@
  * Icinga2
  */
 class { '::icinga2':
-  manage_repo => true,
-  confd       => 'example.d',
+  manage_repos => true,
+  confd        => 'example.d',
 }
 
 file { '/etc/icinga2/example.d':

--- a/examples/init_idomysql.pp
+++ b/examples/init_idomysql.pp
@@ -8,7 +8,7 @@ mysql::db { 'icinga2':
 }
 
 class { '::icinga2':
-  manage_repo => true,
+  manage_repos => true,
 }
 
 class{ '::icinga2::feature::idomysql':

--- a/examples/init_idomysql_ssl.pp
+++ b/examples/init_idomysql_ssl.pp
@@ -97,7 +97,7 @@ mysql::db { 'icinga':
 }
 
 class { '::icinga2':
-  manage_repo => true,
+  manage_repos => true,
 }
 
 class{ '::icinga2::feature::idomysql':

--- a/examples/init_idopgsql.pp
+++ b/examples/init_idopgsql.pp
@@ -6,7 +6,7 @@ postgresql::server::db { 'icinga2':
 }
 
 class{ 'icinga2':
-  manage_repo => true,
+  manage_repos => true,
 }
 
 class{ 'icinga2::feature::idopgsql':

--- a/examples/init_master.pp
+++ b/examples/init_master.pp
@@ -1,6 +1,6 @@
 class { '::icinga2':
-  manage_repo => true,
-  constants   => {
+  manage_repos => true,
+  constants    => {
     'NodeName'   => 'master.localdomain',
     'ZoneName'   => 'master',
     'TicketSalt' => '5a3d695b8aef8f18452fc494593056a4',

--- a/examples/init_repo.pp
+++ b/examples/init_repo.pp
@@ -1,3 +1,0 @@
-class { 'icinga2':
-  manage_repo => true,
-}

--- a/examples/init_repos.pp
+++ b/examples/init_repos.pp
@@ -1,5 +1,3 @@
 class { 'icinga2':
   manage_repos => true,
 }
-
-include icinga2::feature::influxdb

--- a/examples/init_slave.pp
+++ b/examples/init_slave.pp
@@ -2,7 +2,7 @@ $master_cert = 'master.localdomain'
 $master_ip   = '192.168.5.16'
 
 class { '::icinga2':
-  manage_repo  => true,
+  manage_repos => true,
   constants    => {
     'NodeName' => 'slave.localdomain',
   },

--- a/examples/init_slave_validate.pp
+++ b/examples/init_slave_validate.pp
@@ -5,7 +5,7 @@ $master_ip   = '192.168.5.12'
 $fingerprint = 'D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:50:68:01:D8:98:82:1B:14:8A:6A:89:4B:7A:40:32:99:3D:96:72:72'
 
 class { '::icinga2':
-  manage_repo  => true,
+  manage_repos => true,
   constants    => {
     'NodeName' => 'slave.localdomain',
   },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,9 +5,9 @@
 #
 #   include ::icinga2
 #
-# @example If you want to use the official Icinga Project repository, enable the manage_repo parameter.
+# @example If you want to use the module icinga/puppet-icinga, e.g. to use the official Icinga Project repositories, enable the manage_repos parameter.
 #   class { 'icinga2':
-#     manage_repo => true,
+#     manage_repos => true,
 #   }
 #
 # @example If you don't want to manage the Icinga 2 service with puppet, you can dissable this behaviour with the manage_service parameter. When set to false no service refreshes will be triggered.
@@ -39,8 +39,8 @@
 #
 # @example Enabling features with there defaults or loading parameters via Hiera:
 #   class { '::icinga2':
-#     manage_repo => true,
-#     features    => ['checker', 'mainlog', 'command'],
+#     manage_repos => true,
+#     features     => ['checker', 'mainlog', 'command'],
 #   }
 #
 # @example The ITL contains several CheckCommand definitions to load, set these in the array of the plugins parameter, i.e. for a master or satellite do the following and disbale the load of the configuration in conf.d.
@@ -78,9 +78,12 @@
 #   If set to true the Icinga 2 service will start on boot.
 #
 # @param [Boolean] manage_repo
-#   When set to true this module will install the packages.icinga.com repository. With this official repo you can get
-#   the latest version of Icinga. When set to false the operating systems default will be used. As the Icinga Project
-#   does not offer a Chocolatey repository, you will get a warning if you enable this parameter on Windows.
+#   Deprecated, use manage_repos.
+#
+# @param [Boolean] manage_repos
+#   When set to true this module will use the module icinga/puppet-icinga to manage repositories,
+#   e.g. the release repo on packages.icinga.com repository by default, the EPEL repository or Backports.
+#   For more information, see http://github.com/icinga/puppet-icinga.
 #
 # @param [Boolean] manage_package
 #   If set to false packages aren't managed.
@@ -117,6 +120,7 @@ class icinga2 (
   Stdlib::Ensure::Service    $ensure         = running,
   Boolean                    $enable         = true,
   Boolean                    $manage_repo    = false,
+  Boolean                    $manage_repos   = false,
   Boolean                    $manage_package = true,
   Boolean                    $manage_selinux = false,
   Boolean                    $manage_service = true,
@@ -144,8 +148,11 @@ class icinga2 (
   -> Concat <| tag == 'icinga2::config::file' |>
   ~> Class['::icinga2::service']
 
-  if $::icinga2::manage_repo {
+  if $manage_repos or $manage_repo {
     require ::icinga::repos
+    if $manage_repo {
+      deprecation('manage_repo', 'manage_repo is deprecated and will be replaced by manage_repos in the future.')
+    }
   }
 
   anchor { '::icinga2::begin':

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -26,8 +26,8 @@ describe 'icinga2 class' do
         }
 
         class { 'icinga2':
-          manage_repo => true,
-          constants   => {
+          manage_repos => true,
+          constants    => {
             'TicketSalt' => 'topsecret4ticketid',
           },
         }


### PR DESCRIPTION
Add new parameter manage repos to replace some repos later.
If you continue to use manage_repo a warning must be issued.