### PR TITLE
feat: set owner and group for configs

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,16 +22,22 @@ class icinga2::config {
   }
 
   file { "${conf_dir}/constants.conf":
+    owner => $::icinga2::globals::user,
+    group => $::icinga2::globals::group,
     ensure  => file,
     content => $template_constants,
   }
 
   file { "${conf_dir}/icinga2.conf":
+    owner => $::icinga2::globals::user,
+    group => $::icinga2::globals::group,
     ensure  => file,
     content => $template_mainconfig,
   }
 
   file { "${conf_dir}/features-enabled":
+    owner => $::icinga2::globals::user,
+    group => $::icinga2::globals::group,
     ensure  => directory,
     purge   => $purge_features,
     recurse => $purge_features,

--- a/manifests/object.pp
+++ b/manifests/object.pp
@@ -1,8 +1,6 @@
 # @summary
 #   Define resource to used by this module only.
 #
-# @api private
-#
 # @param [Enum['present', 'absent']] ensure
 #   Set to present enables the object, absent disabled it.
 #
@@ -65,8 +63,6 @@ define icinga2::object(
   Array                                                       $ignore       = [],
   Hash                                                        $attrs        = {},
 ) {
-
-  assert_private()
 
   case $::osfamily {
     'windows': {


### PR DESCRIPTION
Currently when you do an installation you get the following error because it falls back to root:

```
==> icinga2_master: Jan 11 06:02:42 localhost.localdomain icinga2[1055]: [2021-01-11 06:02:42 +0000] information/cli: Icinga application loader (version: 2.12.3)
==> icinga2_master: Jan 11 06:02:42 localhost.localdomain icinga2[1055]: [2021-01-11 06:02:42 +0000] information/cli: Loading configuration file(s).
==> icinga2_master: Jan 11 06:02:42 localhost.localdomain icinga2[1055]: [2021-01-11 06:02:42 +0000] critical/cli: Could not compile config files: Error: Function call 'std::ifstream::open' for file '/etc/icinga2/icinga2.conf' failed with error code 13, 'Permission denied'
==> icinga2_master: Jan 11 06:02:42 localhost.localdomain icinga2[1055]: (0) Compiling configuration file '/etc/icinga2/icinga2.conf'
==> icinga2_master: Jan 11 06:02:42 localhost.localdomain systemd[1]: icinga2.service: main process exited, code=exited, status=1/FAILURE

```