### PR TITLE
WIP: Enable adjustments to the Logon Account of the service under Windows

### DIFF
--- a/data/windows-kernel.yaml
+++ b/data/windows-kernel.yaml
@@ -1,6 +1,7 @@
 ---
 icinga2::globals::package_name: icinga2
 icinga2::globals::service_name: icinga2
+icinga2::globals::service_user: 'NetworkService'
 icinga2::globals::ido_mysql_schema: C:/Program Files/icinga2/usr/share/icinga2-ido-mysql/schema/mysql.sql
 icinga2::globals::ido_pgsql_schema: C:/Program Files/icinga2/usr/share/icinga2-ido-pgsql/schema/pgsql.sql
 icinga2::globals::icinga2_bin: C:/Program Files/icinga2/sbin/icinga2.exe

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -15,7 +15,7 @@
 #   User as the icinga process runs.
 #   CAUTION: This does not manage the user context for the runnig icinga 2 process!
 #   The parameter is only used for ownership of files or directories.
-#   
+#
 # @param [Optional[String]] group
 #   Group as the icinga process runs.
 #   CAUTION: This does not manage the group context for the runnig icinga 2 process!
@@ -26,13 +26,13 @@
 #
 # @param [Optional[String]] ido_mysql_package_name
 #   The name of the icinga package that's needed for MySQL.
-#   
+#
 # @param [String] ido_mysql_schema
 #   Path to the MySQL schema to import.
 #
 # @param [Optional[String]] ido_pgsql_package_name
 #   The name of the icinga package that's needed for Postrgesql.
-#   
+#
 # @param [String] ido_pgsql_schema
 #   Path to the Postgresql schema to import.
 #
@@ -66,6 +66,10 @@
 # @param [Optional[String]] service_reload
 #   How to do a reload of the Icinga process.
 #
+# @param [Optional[String]] service_user
+#   The user context in which the service should run.
+#   ATM only relevant on Windows.
+#
 class icinga2::globals(
   String                 $package_name,
   String                 $service_name,
@@ -87,6 +91,7 @@ class icinga2::globals(
   Optional[String]       $ido_mysql_package_name = undef,
   Optional[String]       $ido_pgsql_package_name = undef,
   Optional[String]       $service_reload         = undef,
+  Optional[String]       $service_user           = undef,
 ) {
 
   assert_private()

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,9 +13,19 @@ class icinga2::service {
   $manage_service = $::icinga2::manage_service
   $service_name   = $::icinga2::globals::service_name
   $reload         = $::icinga2::globals::service_reload
+  $service_user   = $::icinga2::globals::service_user
   $hasrestart     = $reload ? {
     undef   => false,
     default => true,
+  }
+
+  if $facts['os']['name'] == 'windows' and versioncmp($puppetversion, "6.18.0") >= 0 {
+    $_extra_service_attrs = {
+      'logonaccount' => $service_user
+    }
+  }
+  else {
+    $_extra_service_attrs = {}
   }
 
   if $manage_service {
@@ -24,6 +34,7 @@ class icinga2::service {
       enable     => $enable,
       hasrestart => $hasrestart,
       restart    => $reload,
+      *          => $_extra_service_attrs
     }
   }
 


### PR DESCRIPTION
This PR enables users to override the logonaccount attribute on Windows nodes if supported by Puppet.
This is necessary for certain check plugins to work, for example the check_updates.exe plugin distributed by default.