### PR TITLE
Changed Integer parameters into Icinga2::Interval

### DIFF
--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -23,7 +23,7 @@
 #   a string to do operations on this dictionary or an array for multiple use
 #   of custom attributes.
 #
-# @param [Optional[Integer[1]]] timeout
+# @param [Optional[Icinga2::Interval]] timeout
 #   The command timeout in seconds.
 #
 # @param [Optional[Variant[Hash, String]]] arguments
@@ -48,7 +48,7 @@ define icinga2::object::checkcommand(
   Optional[Variant[Array, String]]    $command           = undef,
   Optional[Hash]                      $env               = undef,
   Optional[Icinga2::CustomAttributes] $vars              = undef,
-  Optional[Integer[1]]                $timeout           = undef,
+  Optional[Icinga2::Interval]         $timeout           = undef,
   Optional[Variant[Hash, String]]     $arguments         = undef,
   Boolean                             $template          = false,
   Variant[String, Integer]            $order             = 15,

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -20,7 +20,7 @@
 #   a string to do operations on this dictionary or an array for multiple use
 #   of custom attributes.
 #
-# @param [Optional[Integer[1]]] timeout
+# @param [Optional[Icinga2::Interval]] timeout
 #   The command timeout in seconds.
 #
 # @param [Optional[Hash]] arguments
@@ -43,7 +43,7 @@ define icinga2::object::eventcommand (
   Optional[Variant[Array, String]]    $command           = undef,
   Optional[Hash]                      $env               = undef,
   Optional[Icinga2::CustomAttributes] $vars              = undef,
-  Optional[Integer[1]]                $timeout           = undef,
+  Optional[Icinga2::Interval]         $timeout           = undef,
   Optional[Hash]                      $arguments         = undef,
   Array                               $import            = [],
   Variant[String, Integer]            $order             = 20,

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -21,7 +21,7 @@
 #   a string to do operations on this dictionary or an array for multiple use
 #   of custom attributes.
 #
-# @param [Optional[Integer[1]]] timeout
+# @param [Optional[Icinga2::Interval]] timeout
 #   The command timeout in seconds.
 #
 # @param [Optional[Hash]] arguments
@@ -47,7 +47,7 @@ define icinga2::object::notificationcommand (
   Optional[Variant[Array, String]]     $command                  = undef,
   Optional[Hash]                       $env                      = undef,
   Optional[Icinga2::CustomAttributes]  $vars                     = undef,
-  Optional[Integer[1]]                 $timeout                  = undef,
+  Optional[Icinga2::Interval]          $timeout                  = undef,
   Optional[Hash]                       $arguments                = undef,
   Boolean                              $template                 = false,
   Array                                $import                   = [],


### PR DESCRIPTION
Where applicable I changed to parameter types to Icinga2::Interval.
This makes the module more uniform and predictable.

Signed-off-by: Henry Pauli <henry@mixict.nl>