### PR TITLE
Added Dictionary to reserved list

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -26,6 +26,7 @@ icinga2::globals::reserved:
   - Critical
   - Custom
   - Deprecated
+  - Dictionary
   - Down
   - DowntimeEnd
   - DowntimeRemoved


### PR DESCRIPTION
Without this Dictionary keyword gets quoted in (for example) assign.

Puppet
```assign => 'typeof(host.vars.dict) == Dictionary'```

Output before change (wrong):
```assign where typeof(host.vars.dict) == "Dictionary"```

Output after change (correct):
```assign where typeof(host.vars.dict) == Dictionary```

Signed-off-by: Henry Pauli <henry@mixict.nl>