### PR TITLE
fix wrong name o f attribute ssl_enable for influxdb2

### DIFF
--- a/manifests/feature/influxdb2.pp
+++ b/manifests/feature/influxdb2.pp
@@ -137,7 +137,7 @@ class icinga2::feature::influxdb2 (
     )
 
     $attrs_ssl = {
-      enable_ssl            => true,
+      ssl_enable            => true,
       ssl_insecure_noverify => $ssl_noverify,
       ssl_ca_cert           => $cert['cacert_file'],
       ssl_cert              => $cert['cert_file'],
@@ -150,7 +150,7 @@ class icinga2::feature::influxdb2 (
     }
   } else {
     $attrs_ssl = {
-      enable_ssl            => undef,
+      ssl_enable            => undef,
       ssl_insecure_noverify => undef,
       ssl_ca_cert           => undef,
       ssl_cert              => undef,


### PR DESCRIPTION
Otherwise Icinga2 will fail to start:
```
root@blablabl:~# systemctl status icinga2
× icinga2.service - Icinga host/service/network monitoring system
     Loaded: loaded (/lib/systemd/system/icinga2.service; enabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/icinga2.service.d
             └─limits.conf
     Active: failed (Result: exit-code) since Thu 2023-01-12 08:03:02 UTC; 30s ago
    Process: 2153039 ExecStartPre=/usr/lib/icinga2/prepare-dirs /etc/default/icinga2 (code=exited, status=0/SUCCESS)
    Process: 2153044 ExecStart=/usr/sbin/icinga2 daemon --close-stdio -e ${ICINGA2_ERROR_LOG} (code=exited, status=1/FAILURE)
  Main PID: 2153044 (code=exited, status=1/FAILURE)
     Status: "Config validation failed."
        CPU: 128ms

Jan 12 08:03:02 blablabl icinga2[2153086]: /etc/icinga2/features-enabled/influxdb2.conf(23):   enable_send_metadata = true
Jan 12 08:03:02 blablabl icinga2[2153086]: /etc/icinga2/features-enabled/influxdb2.conf(24):   enable_ssl = true
Jan 12 08:03:02 blablabl icinga2[2153086]:                                                     ^^^^^^^^^^^^^^^^^
Jan 12 08:03:02 blablabl icinga2[2153086]: /etc/icinga2/features-enabled/influxdb2.conf(25):   ssl_ca_cert = "/etc/ssl/certs/ca.cer"
Jan 12 08:03:02 blablabl icinga2[2153086]: /etc/icinga2/features-enabled/influxdb2.conf(26):   ssl_cert = "/etc/ssl/certs/blablabl.full.cer"
Jan 12 08:03:02 blablabl icinga2[2153086]: [2023-01-12 08:03:02 +0000] critical/config: 1 error
Jan 12 08:03:02 blablabl icinga2[2153086]: [2023-01-12 08:03:02 +0000] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
Jan 12 08:03:02 blablabl systemd[1]: icinga2.service: Main process exited, code=exited, status=1/FAILURE
Jan 12 08:03:02 blablabl systemd[1]: icinga2.service: Failed with result 'exit-code'.
Jan 12 08:03:02 blablabl systemd[1]: Failed to start Icinga host/service/network monitoring system.
```