### PR TITLE
Add feature to handle large monitoring environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
 Icinga 2 is a widely used open source monitoring software. This Puppet module helps with installing and managing
 configuration of Icinga 2 on multiple operating systems.
 
+### What's new in version 3.6.0
+Each Icinga object has been given the new parameter `export` that specifies one (ordinary objects for the config server) or more nodes (e.g. zones and endpoints for HA servers from workers aka satellites) as targets where the objects are then created using the class `query_objects`. This has been implemented to avoid collecting export resources in large environments.
+
 ### What's new in version 3.5.0
 There are some new function for internal use. Function `icinga2::cert` handels files and/or content for TLS client auth for bot IDO features and for influxdb, infuxdb2, elasticsearch, gelf and icingadb. The function `icinga2::db::connect` provides the client connection string to mysql, mariadb or pgsql databses for both IDO features. 
 
@@ -97,7 +100,7 @@ The use of Icinga's own CA is recommended. If you still want to use the Puppet c
 This module has been tested on:
 
 * Debian 10, 11
-* Ubuntu 18.04, 20.04, 22.04
+* Ubuntu 20.04, 22.04
 * CentOS/RHEL 7, 8, 9
 * AlmaLinux/Rocky 8, 9
 * Fedora 32

--- a/manifests/object/apiuser.pp
+++ b/manifests/object/apiuser.pp
@@ -57,6 +57,9 @@
 # @param [Variant[String, Integer]] order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::apiuser (
   Stdlib::Absolutepath                          $target,
   Enum['absent', 'present']                     $ensure       = present,
@@ -65,6 +68,7 @@ define icinga2::object::apiuser (
   Optional[Variant[String, Sensitive[String]]]  $password     = undef,
   Optional[String]                              $client_cn    = undef,
   Variant[String, Integer]                      $order        = 30,
+  Variant[Array[String], String]                $export       = [],
 ) {
   $_password = if $password =~ String {
     Sensitive($password)
@@ -82,7 +86,7 @@ define icinga2::object::apiuser (
   }
 
   # create object
-  icinga2::object { "icinga2::object::ApiUser::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $apiuser_name,
     object_type => 'ApiUser',
@@ -90,5 +94,16 @@ define icinga2::object::apiuser (
     attrs_list  => keys($attrs),
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::ApiUser::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::ApiUser::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -39,6 +39,8 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
 #
 define icinga2::object::checkcommand (
   Stdlib::Absolutepath                $target,
@@ -52,6 +54,7 @@ define icinga2::object::checkcommand (
   Optional[Variant[Hash, String]]     $arguments         = undef,
   Boolean                             $template          = false,
   Variant[String, Integer]            $order             = 15,
+  Variant[Array[String], String]      $export            = [],
 ) {
   # compose the attributes
   $attrs = {
@@ -63,7 +66,7 @@ define icinga2::object::checkcommand (
   }
 
   # create object
-  icinga2::object { "icinga2::object::CheckCommand::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $checkcommand_name,
     object_type => 'CheckCommand',
@@ -73,5 +76,16 @@ define icinga2::object::checkcommand (
     attrs_list  => keys($attrs),
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::CheckCommand::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::CheckCommand::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -68,27 +68,31 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::dependency (
-  Stdlib::Absolutepath          $target,
-  Enum['absent', 'present']     $ensure                = present,
-  String                        $dependency_name       = $title,
-  Optional[String]              $parent_host_name      = undef,
-  Optional[String]              $parent_service_name   = undef,
-  Optional[String]              $child_host_name       = undef,
-  Optional[String]              $child_service_name    = undef,
-  Optional[Boolean]             $disable_checks        = undef,
-  Optional[Boolean]             $disable_notifications = undef,
-  Optional[Boolean]             $ignore_soft_states    = undef,
-  Optional[String]              $period                = undef,
-  Optional[Array]               $states                = undef,
-  Variant[Boolean, String]      $apply                 = false,
-  Variant[Boolean, String]      $prefix                = false,
-  Enum['Host', 'Service']       $apply_target          = 'Host',
-  Array                         $assign                = [],
-  Array                         $ignore                = [],
-  Array                         $import                = [],
-  Boolean                       $template              = false,
-  Variant[String, Integer]      $order                 = 70,
+  Stdlib::Absolutepath           $target,
+  Enum['absent', 'present']      $ensure                = present,
+  String                         $dependency_name       = $title,
+  Optional[String]               $parent_host_name      = undef,
+  Optional[String]               $parent_service_name   = undef,
+  Optional[String]               $child_host_name       = undef,
+  Optional[String]               $child_service_name    = undef,
+  Optional[Boolean]              $disable_checks        = undef,
+  Optional[Boolean]              $disable_notifications = undef,
+  Optional[Boolean]              $ignore_soft_states    = undef,
+  Optional[String]               $period                = undef,
+  Optional[Array]                $states                = undef,
+  Variant[Boolean, String]       $apply                 = false,
+  Variant[Boolean, String]       $prefix                = false,
+  Enum['Host', 'Service']        $apply_target          = 'Host',
+  Array                          $assign                = [],
+  Array                          $ignore                = [],
+  Array                          $import                = [],
+  Boolean                        $template              = false,
+  Variant[String, Integer]       $order                 = 70,
+  Variant[Array[String], String] $export                = [],
 ) {
   # compose attributes
   $attrs = {
@@ -104,7 +108,7 @@ define icinga2::object::dependency (
   }
 
   # create object
-  icinga2::object { "icinga2::object::Dependency::${title}":
+  $config = {
     ensure       => $ensure,
     object_name  => $dependency_name,
     object_type  => 'Dependency',
@@ -119,5 +123,16 @@ define icinga2::object::dependency (
     ignore       => $ignore,
     target       => $target,
     order        => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::Dependency::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::Dependency::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -26,6 +26,9 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::endpoint (
   Enum['absent', 'present']             $ensure        = present,
   String                                $endpoint_name = $title,
@@ -34,6 +37,7 @@ define icinga2::object::endpoint (
   Optional[Icinga2::Interval]           $log_duration  = undef,
   Optional[Stdlib::Absolutepath]        $target        = undef,
   Variant[String, Integer]              $order         = 40,
+  Variant[Array[String], String]        $export        = [],
 ) {
   $conf_dir = $icinga2::globals::conf_dir
 
@@ -51,7 +55,7 @@ define icinga2::object::endpoint (
   }
 
   # create object
-  icinga2::object { "icinga2::object::Endpoint::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $endpoint_name,
     object_type => 'Endpoint',
@@ -59,5 +63,16 @@ define icinga2::object::endpoint (
     attrs_list  => keys($attrs),
     target      => $_target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::Endpoint::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::Endpoint::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -36,6 +36,9 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::eventcommand (
   Stdlib::Absolutepath                $target,
   Enum['absent', 'present']           $ensure            = present,
@@ -47,6 +50,7 @@ define icinga2::object::eventcommand (
   Optional[Hash]                      $arguments         = undef,
   Array                               $import            = [],
   Variant[String, Integer]            $order             = 20,
+  Variant[Array[String], String]      $export            = [],
 ) {
   # compose the attributes
   $attrs = {
@@ -58,7 +62,7 @@ define icinga2::object::eventcommand (
   }
 
   # create object
-  icinga2::object { "icinga2::object::EventCommand::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $eventcommand_name,
     object_type => 'EventCommand',
@@ -67,5 +71,16 @@ define icinga2::object::eventcommand (
     attrs_list  => keys($attrs),
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::EventCommand::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::EventCommand::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -107,6 +107,9 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::host (
   Stdlib::Absolutepath                $target,
   Enum['absent', 'present']           $ensure                  = present,
@@ -142,6 +145,7 @@ define icinga2::object::host (
   Optional[String]                    $icon_image_alt          = undef,
   Boolean                             $template                = false,
   Variant[String, Integer]            $order                   = 50,
+  Variant[Array[String], String]      $export                  = [],
 ) {
   # compose the attributes
   $attrs = {
@@ -176,7 +180,7 @@ define icinga2::object::host (
   }
 
   # create object
-  icinga2::object { "icinga2::object::Host::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $host_name,
     object_type => 'Host',
@@ -186,5 +190,16 @@ define icinga2::object::host (
     attrs_list  => keys($attrs),
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::Host::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::Host::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/hostgroup.pp
+++ b/manifests/object/hostgroup.pp
@@ -34,15 +34,19 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::hostgroup (
-  Stdlib::Absolutepath        $target,
-  Enum['absent', 'present']   $ensure         = present,
-  String                      $hostgroup_name = $title,
-  Optional[String]            $display_name   = undef,
-  Optional[Array]             $groups         = undef,
-  Array                       $assign         = [],
-  Array                       $ignore         = [],
-  Variant[String, Integer]    $order          = 55,
+  Stdlib::Absolutepath           $target,
+  Enum['absent', 'present']      $ensure         = present,
+  String                         $hostgroup_name = $title,
+  Optional[String]               $display_name   = undef,
+  Optional[Array]                $groups         = undef,
+  Array                          $assign         = [],
+  Array                          $ignore         = [],
+  Variant[String, Integer]       $order          = 55,
+  Variant[Array[String], String] $export         = [],
 ) {
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')
@@ -55,7 +59,7 @@ define icinga2::object::hostgroup (
   }
 
   # create object
-  icinga2::object { "icinga2::object::HostGroup::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $hostgroup_name,
     object_type => 'HostGroup',
@@ -65,5 +69,16 @@ define icinga2::object::hostgroup (
     ignore      => $ignore,
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::HostGroup::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::HostGroup::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/icingaapplication.pp
+++ b/manifests/object/icingaapplication.pp
@@ -41,6 +41,9 @@
 # @param order
 #   String or integer to control the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::icingaapplication (
   Enum['absent', 'present']             $ensure                = present,
   String                                $app_name              = $title,
@@ -54,6 +57,7 @@ define icinga2::object::icingaapplication (
   Optional[String]                      $environment           = undef,
   Optional[Stdlib::Absolutepath]        $target                = undef,
   Variant[String, Integer]              $order                 = 5,
+  Variant[Array[String], String]        $export                = [],
 ) {
   $conf_dir = $icinga2::globals::conf_dir
 
@@ -77,7 +81,7 @@ define icinga2::object::icingaapplication (
   }
 
   # create object
-  icinga2::object { "icinga2::object::IcingaApplication::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $app_name,
     object_type => 'IcingaApplication',
@@ -85,5 +89,16 @@ define icinga2::object::icingaapplication (
     attrs_list  => keys($attrs),
     target      => $_target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::IcingaApplication::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::IcingaApplication::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -78,6 +78,9 @@
 # @param ignore
 #   Exclude notification using the ignore rules.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::notification (
   Stdlib::Absolutepath                                                $target,
   Enum['absent', 'present']                                           $ensure            = present,
@@ -102,6 +105,7 @@ define icinga2::object::notification (
   Array                                                               $import            = [],
   Boolean                                                             $template          = false,
   Variant[String, Integer]                                            $order             = 85,
+  Variant[Array[String], String]                                      $export            = [],
 ) {
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')
@@ -124,7 +128,7 @@ define icinga2::object::notification (
   }
 
   # create object
-  icinga2::object { "icinga2::object::Notification::${title}":
+  $config = {
     ensure       => $ensure,
     object_name  => $notification_name,
     object_type  => 'Notification',
@@ -139,5 +143,16 @@ define icinga2::object::notification (
     apply_target => $apply_target,
     assign       => $assign,
     ignore       => $ignore,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::Notification::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::Notification::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -40,6 +40,9 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::notificationcommand (
   Stdlib::Absolutepath                 $target,
   Enum['absent', 'present']            $ensure                   = present,
@@ -52,6 +55,7 @@ define icinga2::object::notificationcommand (
   Boolean                              $template                 = false,
   Array                                $import                   = [],
   Variant[String, Integer]             $order                    = 25,
+  Variant[Array[String], String]       $export                   = [],
 ) {
   # compose attributes
   $attrs = {
@@ -63,7 +67,7 @@ define icinga2::object::notificationcommand (
   }
 
   # create object
-  icinga2::object { "icinga2::object::NotificationCommand::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $notificationcommand_name,
     object_type => 'NotificationCommand',
@@ -73,5 +77,16 @@ define icinga2::object::notificationcommand (
     attrs_list  => keys($attrs),
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::NotificationCommand::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::NotificationCommand::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -51,6 +51,9 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::scheduleddowntime (
   Stdlib::Absolutepath            $target,
   Enum['absent', 'present']       $ensure                 = present,
@@ -68,6 +71,7 @@ define icinga2::object::scheduleddowntime (
   Array                           $assign                 = [],
   Array                           $ignore                 = [],
   Variant[String, Integer]        $order                  = 90,
+  Variant[Array[String], String]  $export                 = [],
 ) {
   # compose attributes
   $attrs = {
@@ -81,7 +85,7 @@ define icinga2::object::scheduleddowntime (
   }
 
   # create object
-  icinga2::object { "icinga2::object::ScheduledDowntime::${title}":
+  $config = {
     ensure       => $ensure,
     object_name  => $scheduleddowntime_name,
     object_type  => 'ScheduledDowntime',
@@ -94,5 +98,16 @@ define icinga2::object::scheduleddowntime (
     ignore       => $ignore,
     target       => $target,
     order        => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::ScheduledDowntime::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::ScheduledDowntime::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -145,6 +145,9 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::service (
   Stdlib::Absolutepath                       $target,
   Enum['absent', 'present']                  $ensure                  = present,
@@ -183,6 +186,7 @@ define icinga2::object::service (
   Array                                      $import                  = [],
   Boolean                                    $template                = false,
   Variant[String, Integer]                   $order                   = 60,
+  Variant[Array[String], String]             $export                  = [],
 ) {
   # compose the attributes
   $attrs = {
@@ -216,7 +220,7 @@ define icinga2::object::service (
   }
 
   # create object
-  icinga2::object { "icinga2::object::Service::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $service_name,
     object_type => 'Service',
@@ -230,5 +234,16 @@ define icinga2::object::service (
     attrs_list  => keys($attrs),
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::Service::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::Service::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -32,17 +32,21 @@
 # @param [Variant[String, Integer]] order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::servicegroup (
-  Stdlib::Absolutepath          $target,
-  Enum['absent', 'present']     $ensure            = present,
-  String                        $servicegroup_name = $title,
-  Optional[String]              $display_name      = undef,
-  Optional[Array]               $groups            = undef,
-  Array                         $assign            = [],
-  Array                         $ignore            = [],
-  Boolean                       $template          = false,
-  Array                         $import            = [],
-  Variant[String, Integer]      $order             = 65,
+  Stdlib::Absolutepath           $target,
+  Enum['absent', 'present']      $ensure            = present,
+  String                         $servicegroup_name = $title,
+  Optional[String]               $display_name      = undef,
+  Optional[Array]                $groups            = undef,
+  Array                          $assign            = [],
+  Array                          $ignore            = [],
+  Boolean                        $template          = false,
+  Array                          $import            = [],
+  Variant[String, Integer]       $order             = 65,
+  Variant[Array[String], String] $export            = [],
 ) {
   # compose attributes
   $attrs = {
@@ -51,7 +55,7 @@ define icinga2::object::servicegroup (
   }
 
   # create object
-  icinga2::object { "icinga2::object::ServiceGroup::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $servicegroup_name,
     object_type => 'ServiceGroup',
@@ -63,5 +67,16 @@ define icinga2::object::servicegroup (
     ignore      => $ignore,
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::ServiceGroup::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::ServiceGroup::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -35,18 +35,22 @@
 # @param order
 #   String or integer to control the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::timeperiod (
-  Stdlib::Absolutepath         $target,
-  Enum['absent', 'present']    $ensure          = present,
-  String                       $timeperiod_name = $title,
-  Optional[String]             $display_name    = undef,
-  Optional[Hash]               $ranges          = undef,
-  Optional[Boolean]            $prefer_includes = undef,
-  Optional[Array]              $excludes        = undef,
-  Optional[Array]              $includes        = undef,
-  Boolean                      $template        = false,
-  Array                        $import          = ['legacy-timeperiod'],
-  Variant[String, Integer]     $order           = 35,
+  Stdlib::Absolutepath           $target,
+  Enum['absent', 'present']      $ensure          = present,
+  String                         $timeperiod_name = $title,
+  Optional[String]               $display_name    = undef,
+  Optional[Hash]                 $ranges          = undef,
+  Optional[Boolean]              $prefer_includes = undef,
+  Optional[Array]                $excludes        = undef,
+  Optional[Array]                $includes        = undef,
+  Boolean                        $template        = false,
+  Array                          $import          = ['legacy-timeperiod'],
+  Variant[String, Integer]       $order           = 35,
+  Variant[Array[String], String] $export          = [],
 ) {
   # compose attributes
   $attrs = {
@@ -58,7 +62,7 @@ define icinga2::object::timeperiod (
   }
 
   # create object
-  icinga2::object { "icinga2::object::TimePeriod::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $timeperiod_name,
     object_type => 'TimePeriod',
@@ -68,5 +72,16 @@ define icinga2::object::timeperiod (
     attrs_list  => keys($attrs),
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::TimePeriod::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::TimePeriod::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -51,6 +51,9 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::user (
   Stdlib::Absolutepath                $target,
   Enum['absent', 'present']           $ensure               = present,
@@ -67,6 +70,7 @@ define icinga2::object::user (
   Array                               $import               = [],
   Boolean                             $template             = false,
   Variant[String, Integer]            $order                = 75,
+  Variant[Array[String], String]      $export               = [],
 ) {
   # compose attributes
   $attrs = {
@@ -82,7 +86,7 @@ define icinga2::object::user (
   }
 
   # create object
-  icinga2::object { "icinga2::object::User::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $user_name,
     object_type => 'User',
@@ -92,5 +96,16 @@ define icinga2::object::user (
     attrs_list  => keys($attrs),
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::User::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::User::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -32,17 +32,21 @@
 # @param order
 #   String or integer to set the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::usergroup (
-  Stdlib::Absolutepath        $target,
-  Enum['absent', 'present']   $ensure         = present,
-  String                      $usergroup_name = $title,
-  Optional[String]            $display_name   = undef,
-  Array                       $groups         = [],
-  Array                       $assign         = [],
-  Array                       $ignore         = [],
-  Array                       $import         = [],
-  Boolean                     $template       = false,
-  Variant[String, Integer]    $order          = 80,
+  Stdlib::Absolutepath           $target,
+  Enum['absent', 'present']      $ensure         = present,
+  String                         $usergroup_name = $title,
+  Optional[String]               $display_name   = undef,
+  Array                          $groups         = [],
+  Array                          $assign         = [],
+  Array                          $ignore         = [],
+  Array                          $import         = [],
+  Boolean                        $template       = false,
+  Variant[String, Integer]       $order          = 80,
+  Variant[Array[String], String] $export         = [],
 ) {
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')
@@ -55,7 +59,7 @@ define icinga2::object::usergroup (
   }
 
   # create object
-  icinga2::object { "icinga2::object::UserGroup::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $usergroup_name,
     object_type => 'UserGroup',
@@ -67,5 +71,16 @@ define icinga2::object::usergroup (
     ignore      => $ignore,
     target      => $target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::UserGroup::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::UserGroup::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/object/zone.pp
+++ b/manifests/object/zone.pp
@@ -24,6 +24,9 @@
 # @param order
 #   String or integer to control the position in the target file, sorted alpha numeric.
 #
+# @param export
+#   Export object to destination, collected by class `icinga2::query_objects`.
+#
 define icinga2::object::zone (
   Enum['absent', 'present']          $ensure    = present,
   String                             $zone_name = $title,
@@ -32,6 +35,7 @@ define icinga2::object::zone (
   Boolean                            $global    = false,
   Optional[Stdlib::Absolutepath]     $target    = undef,
   Variant[String, Integer]           $order     = 45,
+  Variant[Array[String], String]     $export    = [],
 ) {
   $conf_dir = $icinga2::globals::conf_dir
 
@@ -55,7 +59,7 @@ define icinga2::object::zone (
   }
 
   # create object
-  icinga2::object { "icinga2::object::Zone::${title}":
+  $config = {
     ensure      => $ensure,
     object_name => $zone_name,
     object_type => 'Zone',
@@ -63,5 +67,16 @@ define icinga2::object::zone (
     attrs_list  => keys($attrs),
     target      => $_target,
     order       => $order,
+  }
+
+  unless empty($export) {
+    @@icinga2::object { "icinga2::object::Zone::${title}":
+      tag => prefix(any2array($export), 'icinga2::instance::'),
+      *   => $config,
+    }
+  } else {
+    icinga2::object { "icinga2::object::Zone::${title}":
+      * => $config,
+    }
   }
 }

--- a/manifests/query_objects.pp
+++ b/manifests/query_objects.pp
@@ -1,0 +1,56 @@
+# @summary
+#   Class to query `icinga2::objects` from puppetdb.
+#
+# @param destination
+#   Destination equal to what was set in parameter `export` for objects.
+#
+# @param environments
+#   limits the response to objects of these environments
+#
+class icinga2::query_objects (
+  String        $destination  = $facts['networking']['fqdn'],
+  Array[String] $environments = [$environment],
+) {
+  $_environments = join($environments, "'")
+
+  case $facts['os']['family'] {
+    'windows': {
+    } # windows
+    default: {
+      Concat {
+        owner => $icinga2::globals::user,
+        group => $icinga2::globals::group,
+        mode  => '0640',
+      }
+    } # default
+  }
+
+  $pql_query =  puppetdb_query("resources[parameters] { environment in ['${_environments}'] and type = 'Icinga2::Object' and exported = true and tag = 'icinga2::instance::${destination}' and nodes { deactivated is null and expired is null } order by certname }")
+
+  $file_list = $pql_query.map |$object| {
+    $object['parameters']['target']
+  }
+
+  unique($file_list).each |$target| {
+    $objects = $pql_query.filter |$object| { $target == $object['parameters']['target'] }
+
+    $_content = $facts['os']['family'] ? {
+      'windows' => regsubst(epp('icinga2/objects.epp', { 'objects' => $objects }), '\n', "\r\n", 'EMG'),
+      default   => epp('icinga2/objects.epp', { 'objects' => $objects }),
+    }
+
+    if !defined(Concat[$target]) {
+      concat { $target:
+        ensure => present,
+        tag    => 'icinga2::config::file',
+        warn   => true,
+      }
+    }
+
+    concat::fragment { "custom-${target}":
+      target  => $target,
+      content => $_content,
+      order   => 99,
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]

--- a/spec/defines/objects_spec.rb
+++ b/spec/defines/objects_spec.rb
@@ -191,5 +191,16 @@ on_icinga_objects.each do |otype, rtype|
 
       it { is_expected.to compile }
     end
+
+    context 'with export => foobar' do
+      let(:params) do
+        {
+          target: '/bar/baz',
+          export: 'foobar'
+        }
+      end
+
+      it { expect(exported_resources).to contain_icinga2__object("icinga2::object::#{otype}::foo").with_object_type(otype) }
+    end
   end
 end

--- a/templates/object.conf.epp
+++ b/templates/object.conf.epp
@@ -1,14 +1,17 @@
 <%- | Hash $attrs,
       Array $attrs_list,
-      Variant[String, Boolean] $apply,
+      Variant[String, Boolean] $apply = false,
       Optional[String] $apply_target = undef,
-      Variant[String, Boolean] $prefix,
+      Variant[String, Boolean] $prefix = false,
       String $object_type,
       String $object_name,
-      Boolean $template,
-      Array $import,
+      Boolean $template = false,
+      Array $import = [],
+      Array $assign = [],
+      Array $ignore = [],
 | -%>
 
+<% $_attrs = merge($attrs, { 'assign where' => $assign, 'ignore where' => $ignore, }) -%>
 <% if $apply =~ String { %>apply <%= $object_type -%>
 <% if $prefix { -%>
 <% if $prefix =~ String { %> "<%= $prefix %>"<% } else { -%>
@@ -34,10 +37,10 @@
 <% } -%>
 <% unless $import =~ Array[Data,0,0] { %><%= "\n" %><% } -%>
 <% if $apply =~String and $apply =~ /^([A-Za-z_]+)\s+in\s+.+$/ { -%>
-<%= icinga2::parse($attrs, 2, $attrs_list, {$1=>{}}) -%>
+<%= icinga2::parse($_attrs, 2, $attrs_list, {$1=>{}}) -%>
 <% } elsif $apply =~ String and $apply =~ /^([A-Za-z_]+)\s+=>\s+([A-Za-z_]+)\s+in\s+.+$/ { -%>
-<%= icinga2::parse($attrs, 2, $attrs_list+[$1], {$2=>{}}) -%>
+<%= icinga2::parse($_attrs, 2, $attrs_list+[$1], {$2=>{}}) -%>
 <% } else { -%>
-<%= icinga2::parse($attrs, 2, $attrs_list) -%>
+<%= icinga2::parse($_attrs, 2, $attrs_list) -%>
 <% } -%>
 }

--- a/templates/objects.epp
+++ b/templates/objects.epp
@@ -1,0 +1,5 @@
+<%- | Array $objects | -%>
+
+<% $objects.each |$object| { -%>
+<%= epp('icinga2/object.conf.epp', delete($object['parameters'], ['order', 'target', 'ensure', 'tag'])) -%>
+<% } -%>


### PR DESCRIPTION
Add a parameter `export` to each Icinga object to set a target for the object. On the target node the objects will be collected by the new class `query_objects`.

Only the underlying defined resource `icinga2::object` is exported, the class `query_objects` queries the puppetdb directly and creates the config files. 