### PR TITLE
make object-collection deterministic in icinga2::query_objects

### DIFF
--- a/manifests/query_objects.pp
+++ b/manifests/query_objects.pp
@@ -25,7 +25,7 @@ class icinga2::query_objects (
     } # default
   }
 
-  $pql_query =  puppetdb_query("resources[parameters] { environment in ['${_environments}'] and type = 'Icinga2::Object' and exported = true and tag = 'icinga2::instance::${destination}' and nodes { deactivated is null and expired is null } order by certname }")
+  $pql_query =  puppetdb_query("resources[parameters] { environment in ['${_environments}'] and type = 'Icinga2::Object' and exported = true and tag = 'icinga2::instance::${destination}' and nodes { deactivated is null and expired is null } order by certname, title }")
 
   $file_list = $pql_query.map |$object| {
     $object['parameters']['target']


### PR DESCRIPTION
Sort all objects by title, so the order will stable and not produce huge changesets by random chance.

Currently the order is random and will/might change between puppet runs.