### PR TITLE
Fix namespaced Functions of stdlib

### DIFF
--- a/manifests/feature/elasticsearch.pp
+++ b/manifests/feature/elasticsearch.pp
@@ -202,7 +202,7 @@ class icinga2::feature::elasticsearch(
   icinga2::object { 'icinga2::object::ElasticsearchWriter::elasticsearch':
     object_name => 'elasticsearch',
     object_type => 'ElasticsearchWriter',
-    attrs       => delete_undef_values(merge($attrs, $attrs_ssl)),
+    attrs       => delete_undef_values(stdlib::merge($attrs, $attrs_ssl)),
     attrs_list  => keys($attrs),
     target      => "${conf_dir}/features-available/elasticsearch.conf",
     notify      => $_notify,

--- a/manifests/feature/idomysql.pp
+++ b/manifests/feature/idomysql.pp
@@ -311,7 +311,7 @@ class icinga2::feature::idomysql(
   icinga2::object { 'icinga2::object::IdoMysqlConnection::ido-mysql':
     object_name => 'ido-mysql',
     object_type => 'IdoMysqlConnection',
-    attrs       => delete_undef_values(merge($attrs, $attrs_ssl)),
+    attrs       => delete_undef_values(stdlib::merge($attrs, $attrs_ssl)),
     attrs_list  => concat(keys($attrs), keys($attrs_ssl)),
     target      => "${conf_dir}/features-available/ido-mysql.conf",
     order       => 10,

--- a/manifests/feature/influxdb.pp
+++ b/manifests/feature/influxdb.pp
@@ -229,7 +229,7 @@ class icinga2::feature::influxdb(
   icinga2::object { 'icinga2::object::InfluxdbWriter::influxdb':
     object_name => 'influxdb',
     object_type => 'InfluxdbWriter',
-    attrs       => delete_undef_values(merge($attrs, $attrs_ssl)),
+    attrs       => delete_undef_values(stdlib::merge($attrs, $attrs_ssl)),
     attrs_list  => keys($attrs),
     target      => "${conf_dir}/features-available/influxdb.conf",
     notify      => $_notify,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,7 +139,7 @@ class icinga2 (
   $_reserved = $::icinga2::globals::reserved
 
   # merge constants with defaults
-  $_constants = merge($::icinga2::globals::constants, $constants)
+  $_constants = stdlib::merge($::icinga2::globals::constants, $constants)
 
   # validate confd, boolean or string
   if $confd =~ Boolean {

--- a/manifests/object.pp
+++ b/manifests/object.pp
@@ -84,7 +84,7 @@ define icinga2::object(
     fail('The object type must be different from the apply target')
   }
 
-  $_attrs = merge($attrs, {
+  $_attrs = stdlib::merge($attrs, {
     'assign where' => $assign,
     'ignore where' => $ignore,
   })

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Stdlib deprecated some non-namespaced Functions.  So use the namespaced ones.