### PR TITLE
Fix not working object export on not icinga agent or server

### DIFF
--- a/manifests/object/apiuser.pp
+++ b/manifests/object/apiuser.pp
@@ -26,7 +26,7 @@
 #         permission => 'objects/query/Host',
 #         filter     => '{{ regex("^Linux", host.vars.os) }}'
 #       },
-#       { 
+#       {
 #         permission => 'objects/query/Service',
 #         filter     => '{{ regex("^Linux", host.vars.os) }}'
 #       },
@@ -70,6 +70,8 @@ define icinga2::object::apiuser (
   Variant[String, Integer]                      $order        = 30,
   Variant[Array[String], String]                $export       = [],
 ) {
+  require icinga2::globals
+
   $_password = if $password =~ String {
     Sensitive($password)
   } elsif $password =~ Sensitive {

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -56,6 +56,8 @@ define icinga2::object::checkcommand (
   Variant[String, Integer]            $order             = 15,
   Variant[Array[String], String]      $export            = [],
 ) {
+  require icinga2::globals
+
   # compose the attributes
   $attrs = {
     'command'   => $command,

--- a/manifests/object/checkresultreader.pp
+++ b/manifests/object/checkresultreader.pp
@@ -24,6 +24,8 @@ define icinga2::object::checkresultreader (
   Optional[Stdlib::Absolutepath]     $spool_dir              = undef,
   Variant[String, Integer]           $order                  = '05',
 ) {
+  require icinga2::globals
+
   # compose the attributes
   $attrs = {
     'spool_dir'   => $spool_dir,

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -94,6 +94,8 @@ define icinga2::object::dependency (
   Variant[String, Integer]       $order                 = 70,
   Variant[Array[String], String] $export                = [],
 ) {
+  require icinga2::globals
+
   # compose attributes
   $attrs = {
     'parent_host_name'      => $parent_host_name,

--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -39,6 +39,7 @@ define icinga2::object::endpoint (
   Variant[String, Integer]              $order         = 40,
   Variant[Array[String], String]        $export        = [],
 ) {
+  require icinga2::globals
   $conf_dir = $icinga2::globals::conf_dir
 
   if $target {

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -52,6 +52,8 @@ define icinga2::object::eventcommand (
   Variant[String, Integer]            $order             = 20,
   Variant[Array[String], String]      $export            = [],
 ) {
+  require icinga2::globals
+
   # compose the attributes
   $attrs = {
     'command'   => $command,

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -147,6 +147,8 @@ define icinga2::object::host (
   Variant[String, Integer]            $order                   = 50,
   Variant[Array[String], String]      $export                  = [],
 ) {
+  require icinga2::globals
+
   # compose the attributes
   $attrs = {
     'address'                 => $address,

--- a/manifests/object/hostgroup.pp
+++ b/manifests/object/hostgroup.pp
@@ -48,6 +48,8 @@ define icinga2::object::hostgroup (
   Variant[String, Integer]       $order          = 55,
   Variant[Array[String], String] $export         = [],
 ) {
+  require icinga2::globals
+
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')
   }

--- a/manifests/object/icingaapplication.pp
+++ b/manifests/object/icingaapplication.pp
@@ -59,6 +59,7 @@ define icinga2::object::icingaapplication (
   Variant[String, Integer]              $order                 = 5,
   Variant[Array[String], String]        $export                = [],
 ) {
+  require icinga2::globals
   $conf_dir = $icinga2::globals::conf_dir
 
   # set defaults

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -107,6 +107,8 @@ define icinga2::object::notification (
   Variant[String, Integer]                                            $order             = 85,
   Variant[Array[String], String]                                      $export            = [],
 ) {
+  require icinga2::globals
+
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')
   }

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -57,6 +57,8 @@ define icinga2::object::notificationcommand (
   Variant[String, Integer]             $order                    = 25,
   Variant[Array[String], String]       $export                   = [],
 ) {
+  require icinga2::globals
+
   # compose attributes
   $attrs = {
     'command'   => $command,

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -73,6 +73,8 @@ define icinga2::object::scheduleddowntime (
   Variant[String, Integer]        $order                  = 90,
   Variant[Array[String], String]  $export                 = [],
 ) {
+  require icinga2::globals
+
   # compose attributes
   $attrs = {
     'host_name'    => $host_name,

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -188,6 +188,8 @@ define icinga2::object::service (
   Variant[String, Integer]                   $order                   = 60,
   Variant[Array[String], String]             $export                  = [],
 ) {
+  require icinga2::globals
+
   # compose the attributes
   $attrs = {
     'display_name'            => $display_name,

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -48,6 +48,8 @@ define icinga2::object::servicegroup (
   Variant[String, Integer]       $order             = 65,
   Variant[Array[String], String] $export            = [],
 ) {
+  require icinga2::globals
+
   # compose attributes
   $attrs = {
     'display_name'  => $display_name,

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -52,6 +52,8 @@ define icinga2::object::timeperiod (
   Variant[String, Integer]       $order           = 35,
   Variant[Array[String], String] $export          = [],
 ) {
+  require icinga2::globals
+
   # compose attributes
   $attrs = {
     'display_name'    => $display_name,

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -72,6 +72,8 @@ define icinga2::object::user (
   Variant[String, Integer]            $order                = 75,
   Variant[Array[String], String]      $export               = [],
 ) {
+  require icinga2::globals
+
   # compose attributes
   $attrs = {
     'display_name'         => $display_name,

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -48,6 +48,8 @@ define icinga2::object::usergroup (
   Variant[String, Integer]       $order          = 80,
   Variant[Array[String], String] $export         = [],
 ) {
+  require icinga2::globals
+
   if $ignore != [] and $assign == [] {
     fail('When attribute ignore is used, assign must be set.')
   }

--- a/manifests/object/zone.pp
+++ b/manifests/object/zone.pp
@@ -37,6 +37,7 @@ define icinga2::object::zone (
   Variant[String, Integer]           $order     = 45,
   Variant[Array[String], String]     $export    = [],
 ) {
+  require icinga2::globals
   $conf_dir = $icinga2::globals::conf_dir
 
   # set defaults


### PR DESCRIPTION
#### Pull Request (PR) description
Fix not working object export on not icinga agent or server.

Add requirement of class `icinga2::globals` for all `icinga2::object::*` defines to ensure that value `icinga2::globals::reserved` exist before EPP is compiled.

#### This Pull Request (PR) fixes the following issues
Fixes #759