### PR TITLE
fixtures.yml: Pull dependencies from git

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,18 +1,10 @@
+---
 fixtures:
-  forge_modules:
-    icinga:
-      repo: icinga/icinga
-    stdlib:
-      repo: puppetlabs/stdlib
-    concat:
-      repo: puppetlabs/concat
-    apt:
-      repo: puppetlabs/apt
-    chocolatey:
-      repo: puppetlabs/chocolatey
-    zypprepo:
-      repo: puppet/zypprepo
-    yumrepo_core:
-      repo: puppetlabs-yumrepo_core
-      puppet_version: ">= 6.0.0"
-
+  repositories:
+    icinga: https://github.com/voxpupuli/puppet-icinga
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
+    concat: https://github.com/puppetlabs/puppetlabs-concat
+    apt: https://github.com/puppetlabs/puppetlabs-apt
+    chocolatey: https://github.com/puppetlabs/puppetlabs-chocolatey
+    zypprepo: https://github.com/voxpupuli/puppet-zypprepo
+    yumrepo_core: https://github.com/puppetlabs/puppetlabs-yumrepo_core


### PR DESCRIPTION
This is the current best practice. In unit tests the .fixtures.yml will be used and we're able to detect breaking changes in dependencies before they are released. In acceptance tests the latest forge releases based on metadata.json will be used.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
