### PR TITLE
Add missing `redundancy_group` param to the dependency object type

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3116,6 +3116,7 @@ The following parameters are available in the `icinga2::object::dependency` defi
 * [`parent_service_name`](#-icinga2--object--dependency--parent_service_name)
 * [`child_host_name`](#-icinga2--object--dependency--child_host_name)
 * [`child_service_name`](#-icinga2--object--dependency--child_service_name)
+* [`redundancy_group`](#-icinga2--object--dependency--redundancy_group)
 * [`disable_checks`](#-icinga2--object--dependency--disable_checks)
 * [`disable_notifications`](#-icinga2--object--dependency--disable_notifications)
 * [`ignore_soft_states`](#-icinga2--object--dependency--ignore_soft_states)
@@ -3179,6 +3180,14 @@ Data type: `Optional[String[1]]`
 
 The child service. If omitted, this dependency object is treated as host
 dependency.
+
+Default value: `undef`
+
+##### <a name="-icinga2--object--dependency--redundancy_group"></a>`redundancy_group`
+
+Data type: `Optional[String[1]]`
+
+The redundancy group - puts the dependency into a group of mutually redundant ones.
 
 Default value: `undef`
 

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -21,6 +21,9 @@
 #   The child service. If omitted, this dependency object is treated as host
 #   dependency.
 #
+# @param redundancy_group
+#   The redundancy group - puts the dependency into a group of mutually redundant ones.
+#
 # @param disable_checks
 #   Whether to disable checks when this dependency fails.
 #
@@ -79,6 +82,7 @@ define icinga2::object::dependency (
   Optional[String[1]]                  $parent_service_name   = undef,
   Optional[String[1]]                  $child_host_name       = undef,
   Optional[String[1]]                  $child_service_name    = undef,
+  Optional[String[1]]                  $redundancy_group      = undef,
   Optional[Boolean]                    $disable_checks        = undef,
   Optional[Boolean]                    $disable_notifications = undef,
   Optional[Boolean]                    $ignore_soft_states    = undef,
@@ -102,6 +106,7 @@ define icinga2::object::dependency (
     'parent_service_name'   => $parent_service_name,
     'child_host_name'       => $child_host_name,
     'child_service_name'    => $child_service_name,
+    'redundancy_group'      => $redundancy_group,
     'disable_checks'        => $disable_checks,
     'disable_notifications' => $disable_notifications,
     'ignore_soft_states'    => $ignore_soft_states,


### PR DESCRIPTION
A `redundancy_group` attribute was [added to the Dependency object in Icinga 2.14](https://icinga.com/blog/2023/10/11/dependency-redundancy-groups-in-icinga-2-14/). This adds support for this to the associated type.

Fixes #789