### PR TITLE
Add feature to remove preset constants via setting them to undef

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,7 +139,7 @@ class icinga2 (
   $_reserved = $icinga2::globals::reserved
 
   # merge constants with defaults
-  $_constants = $icinga2::globals::constants + $constants
+  $_constants = delete_undef_values($icinga2::globals::constants + $constants)
 
   # validate confd, boolean or string
   if $confd =~ Boolean {


### PR DESCRIPTION
```
class { 'icinga2':
  constants => {
    'TicksetSalt' => undef,
  },
}
```
Remove TicketSalt from preset default constants and make it possible to set TicketSalt in an external file and leave the content of TicketSalt unmanaged.

But keep in mind, now, the use of TicketSalt will be interpreted as string aka a quoted expression, e.g. in /etc/icinga2/feature-enabled/api.conf.

That is a security impact! Because the secret is "TicketSalt" not what you've set.

The following hiera data entries will fix this behavior:
```
---
icinga2::globals::reserved:
  - 'TicketSalt'

lookup_options:
  icinga2::globals::reserved:
    merge: unique
```