### PR TITLE
Move lookup for `icinga2::globals::constants` to Hiera

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,7 @@
 ---
+lookup_options:
+  icinga2::globals::constants:
+    merge: deep
 icinga2::plugins:
   - plugins
   - plugins-contrib

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -73,6 +73,8 @@
 # @param service_reload
 #   How to do a reload of the Icinga process.
 #
+# @param $constants
+#   Define Icinga constants
 class icinga2::globals (
   String[1]              $package_name,
   String[1]              $service_name,
@@ -96,8 +98,7 @@ class icinga2::globals (
   Optional[String[1]]    $ido_mysql_package_name = undef,
   Optional[String[1]]    $ido_pgsql_package_name = undef,
   Optional[String[1]]    $service_reload         = undef,
+  Hash[String, Any]      $constants              = {},
 ) {
   assert_private()
-
-  $constants =  lookup('icinga2::globals::constants', Hash, 'deep', {})
 }


### PR DESCRIPTION
This allows overwriting the lookup behavior if needed.

See https://github.com/voxpupuli/puppet-icinga2/issues/803 for more information

#### Pull Request (PR) description
With this PR, you can overwrite the merge behavior and, for example, set different defaults than those defined in [common.yaml#L11](https://github.com/voxpupuli/puppet-icinga2/blob/main/data/common.yaml#L11). This is useful if, for instance, you don't want to use the default `TicketSalt: ''` constant.

```yaml
# Set new lookup behavior
lookup_options:
  icinga2::globals::constants:
    merge: first

# Define new icinga2::constants
icinga2::constants:
  ZoneName: "master"
...
```

#### This Pull Request (PR) fixes the following issues
Fixes #803
