### PR TITLE
Add MatchAny and MatchAll to the list of reserved word

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -59,6 +59,8 @@ icinga2::globals::reserved:
   - LogInformation
   - LogNotice
   - LogWarning
+  - MatchAll
+  - MatchAny
   - Math
   - MaxConcurrentChecks
   - ModAttrPath


### PR DESCRIPTION
fixes #809 