### PR TITLE
Drop puppet, update openvox minimum version to 8.19

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 ---
 fixtures:
   repositories:
-    apt: https://github.com/puppetlabs/puppetlabs-apt
+    apt:
+      repo: https://github.com/puppetlabs/puppetlabs-apt
+      tag: v10.0.1
     chocolatey: https://github.com/puppetlabs/puppetlabs-chocolatey
     concat: https://github.com/puppetlabs/puppetlabs-concat
     icinga: https://github.com/voxpupuli/puppet-icinga

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 ---
 fixtures:
   repositories:
-    apt:
-      repo: https://github.com/puppetlabs/puppetlabs-apt
-      tag: v10.0.1
+    apt: https://github.com/puppetlabs/puppetlabs-apt
     chocolatey: https://github.com/puppetlabs/puppetlabs-chocolatey
     concat: https://github.com/puppetlabs/puppetlabs-concat
     icinga: https://github.com/voxpupuli/puppet-icinga

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -245,15 +245,23 @@ with:
 BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_setfile=debian11-64 bundle exec rake beaker
 ```
 
+or
+
+```sh
+BEAKER_PUPPET_COLLECTION=none BEAKER_setfile=archlinux-64 bundle exec rake beaker
+```
+
+This latter example will use the distribution's own version of Puppet.
+
 You can replace the string `debian11` with any common operating system.
 The following strings are known to work:
 
 * ubuntu2004
 * ubuntu2204
 * debian11
-* centos7
-* centos8
+* debian12
 * centos9
+* archlinux
 * almalinux8
 * almalinux9
 * fedora36

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
 ---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
 skip-changelog:
  - head-branch: ['^release-*', 'release']

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,42 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - modulesync
+      - question
+      - skip-changelog
+      - wont-fix
+      - wontfix
+
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - backwards-incompatible
+
+    - title: New Features 🎉
+      labels:
+        - enhancement
+
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+
+    - title: Documentation Updates 📚
+      labels:
+        - documentation
+        - docs
+
+    - title: Dependency Updates ⬆️
+      labels:
+        - dependencies
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   puppet:
     name: Puppet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@
 
 name: CI
 
+# yamllint disable-line rule:truthy
 on:
   pull_request: {}
   push:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+name: "Pull Request Labeler"
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target: {}
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,10 @@ name: "Pull Request Labeler"
 on:
   pull_request_target: {}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -11,6 +11,10 @@ on:
         description: 'Module version to be released. Must be a valid semver string without leading v. (1.2.3)'
         required: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release_prep:
     uses: 'voxpupuli/gha-puppet/.github/workflows/prepare_release.yml@v3'

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,23 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+name: 'Prepare Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Module version to be released. Must be a valid semver string without leading v. (1.2.3)'
+        required: false
+
+jobs:
+  release_prep:
+    uses: 'voxpupuli/gha-puppet/.github/workflows/prepare_release.yml@v3'
+    with:
+      version: ${{ github.event.inputs.version }}
+      allowed_owner: 'voxpupuli'
+    secrets:
+      # Configure secrets here:
+      #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
+      github_pat: '${{ secrets.PCCI_PAT_RELEASE_PREP }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@
 
 name: Release
 
+# yamllint disable-line rule:truthy
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '9.7.0'
+modulesync_config_version: '10.0.0'

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '9.5.0'
+modulesync_config_version: '9.7.0'

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '9.4.0'
+modulesync_config_version: '9.5.0'

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '9.0.0'
+modulesync_config_version: '9.4.0'

--- a/.pmtignore
+++ b/.pmtignore
@@ -20,6 +20,7 @@
 /.github/
 /.librarian/
 /Puppetfile.lock
+/Puppetfile
 *.iml
 /.editorconfig
 /.fixtures.yml

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,4 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
 --fail-on-warnings

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  "recommendations": [
-    "puppet.puppet-vscode",
-    "rebornix.Ruby"
-  ]
-}

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem 'voxpupuli-test', '~> 9.0',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
-  gem 'puppet_metadata', '~> 4.0',  :require => false
+  gem 'puppet_metadata', '~> 5.0',  :require => false
 end
 
 group :development do
@@ -16,7 +16,7 @@ group :development do
 end
 
 group :system_tests do
-  gem 'voxpupuli-acceptance', '~> 3.0',  :require => false
+  gem 'voxpupuli-acceptance', '~> 3.5',  :require => false
 end
 
 group :release do

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
-  gem 'voxpupuli-test', '~> 8.0',   :require => false
+  gem 'voxpupuli-test', '~> 9.0',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 4.0',  :require => false
@@ -26,7 +26,7 @@ end
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_GEM_VERSION'] || '~> 7.24'
+puppetversion = ENV['PUPPET_GEM_VERSION'] || [">= 7.24", "< 9"]
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
-  gem 'voxpupuli-test', '~> 9.0',   :require => false
-  gem 'coveralls',                  :require => false
-  gem 'simplecov-console',          :require => false
+  gem 'voxpupuli-test', '~> 10.0',  :require => false
   gem 'puppet_metadata', '~> 5.0',  :require => false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
-  gem 'voxpupuli-test', '~> 10.0',  :require => false
+  gem 'voxpupuli-test', '~> 11.0',  :require => false
   gem 'puppet_metadata', '~> 5.0',  :require => false
 end
 
@@ -18,13 +18,11 @@ group :system_tests do
 end
 
 group :release do
-  gem 'voxpupuli-release', '~> 3.0',  :require => false
+  gem 'voxpupuli-release', '~> 4.0',  :require => false
 end
 
 gem 'rake', :require => false
-gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_GEM_VERSION'] || [">= 7.24", "< 9"]
-gem 'puppet', puppetversion, :require => false, :groups => [:test]
+gem 'openvox', ENV.fetch('OPENVOX_GEM_VERSION', [">= 7", "< 9"]), :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/metadata.json
+++ b/metadata.json
@@ -105,12 +105,8 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.9.0 < 9.0.0"
-    },
-    {
       "name": "openvox",
-      "version_requirement": ">= 7.9.0 < 9.0.0"
+      "version_requirement": ">= 8.19.0 < 9.0.0"
     }
   ],
   "tags": [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,10 @@ ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
 
 require 'voxpupuli/test/spec_helper'
 
+RSpec.configure do |c|
+  c.facterdb_string_keys = false
+end
+
 add_mocked_facts!
 
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))


### PR DESCRIPTION
* drop support for puppet as discussed in [1]
* update openvox minimum version to 8.19.0 as discussed in [2] and [3]

[1] https://github.com/voxpupuli/community-triage/issues/59
[2] https://github.com/voxpupuli/community-triage/issues/60
[3] https://github.com/voxpupuli/modulesync_config/pull/978#discussion_r2232830327
