### PR TITLE
Fix internal Icinga2 PKI to handle manual CA signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 4. [Usage - Configuration options and additional functionality](#usage)
     * [Installing Icinga](#installing-icinga)
     * [Clustering Icinga](#clustering-icinga)
+    * [Icinga CA](#icinga-ca)
     * [Config Objects](#config-objects)
     * [Reading objects from hiera](#Reading-objects-from-hiera)
     * [Apply Rules](#apply-rules)
@@ -289,6 +290,38 @@ icinga2::object::zone { 'global-templates':
 The parameter `fingerprint` is optional and new since v2.1.0. It's used to validate the certificate of the CA host.
 You can get the fingerprint via `openssl x509 -noout -fingerprint -sha256 -inform pem -in master.crt` on the master host. (Icinga2 versions before 2.12.0 require '-sha1' as digest algorithm.)
 
+### Icinga CA
+
+To use internal Icinga CA, one node should be configured as CA, see [CA Configuration](#ca-configuration).
+On install, nodes will generate a temporary self-signed cert to be signed by the CA.
+Each cert request must be signed manually on CA host, see [Node Enrollment](#node-enrollment).
+
+#### CA Configuration
+``` puppet
+# Include this class on one node that will act as CA
+include icinga2::pki::ca
+
+# Set it as ca_host in api class
+class { 'icinga2::feature::api':
+...
+  ca_host         => '172.16.1.11',
+}
+```
+
+#### Node Enrollment
+
+1. Run puppet on the node to be enrolled, this will create a temporary self-signed cert and trigger a sign request on CA host.
+2. Sign the pending cert request on ca_host.
+``` puppet
+# icinga2 ca list
+Fingerprint                                                      | Timestamp                | Signed | Subject
+-----------------------------------------------------------------|--------------------------|--------|--------
+045152ef845f91626d0ac7df1182cd29aaa82a1a4cc3141a0f28e184e8e07cec | Jan 26 14:26:59 2026 GMT |        | CN = foobar.domain.com
+
+# icinga2 ca sign 045152ef845f91626d0ac7df1182cd29aaa82a1a4cc3141a0f28e184e8e07cec
+information/cli: Signed certificate for 'CN = foobar.domain.com'.
+```
+3. Run puppet again on node to be enrolled, self-signed cert will be overwritten with CA signed cert.
 
 ### Config Objects
 

--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -328,9 +328,9 @@ class icinga2::feature::api (
         creates => $trusted_cert,
       }
 
-      -> exec { 'icinga2 pki request':
+      -> exec { "icinga2 pki enroll (Check pending requests on CA host with: 'icinga2 ca list')":
         command => "\"${icinga2_bin}\" pki request --host ${ca_host} --port ${ca_port} --ca ${_ssl_cacert_path} --key ${_ssl_key_path} --cert ${_ssl_cert_path} --trustedcert ${trusted_cert} ${_ticket}", # lint:ignore:140chars
-        creates => $_ssl_cacert_path,
+        unless  => "\"${icinga2_bin}\" pki verify --ca ${_ssl_cacert_path} --cert ${_ssl_cert_path}",
       }
     } # icinga2
   } # case pki

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -230,12 +230,12 @@ describe('icinga2::feature::api', type: :class) do
         }
 
         it {
-          is_expected.to contain_exec('icinga2 pki request').with(
+          is_expected.to contain_exec("icinga2 pki enroll (Check pending requests on CA host with: 'icinga2 ca list')").with(
             {
               'command' => "\"#{icinga2_bin}\" pki request --host foo --port 1234 --ca #{icinga2_pki_dir}/ca.crt" \
                 " --key #{icinga2_pki_dir}/host.example.org.key --cert #{icinga2_pki_dir}/host.example.org.crt --trustedcert #{icinga2_pki_dir}/trusted-cert.crt" \
                 ' --ticket ac5cb0d8c98f3f50ceff399b3cfedbb03782c117',
-              'creates' => "#{icinga2_pki_dir}/ca.crt",
+              'unless' => "\"#{icinga2_bin}\" pki verify --ca #{icinga2_pki_dir}/ca.crt --cert #{icinga2_pki_dir}/host.example.org.crt",
             },
           ).that_notifies('Class[icinga2::service]')
         }

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -272,11 +272,11 @@ describe('icinga2::feature::api', type: :class) do
         }
 
         it {
-          is_expected.to contain_exec('icinga2 pki request').with(
+          is_expected.to contain_exec("icinga2 pki enroll (Check pending requests on CA host with: 'icinga2 ca list')").with(
             {
               'command' => "\"#{icinga2_bin}\" pki request --host foo --port 1234 --ca #{icinga2_pki_dir}/ca.crt --key #{icinga2_pki_dir}/host.example.org.key" \
                 " --cert #{icinga2_pki_dir}/host.example.org.crt --trustedcert #{icinga2_pki_dir}/trusted-cert.crt --ticket bar",
-              'creates' => "#{icinga2_pki_dir}/ca.crt",
+              'unless' => "\"#{icinga2_bin}\" pki verify --ca #{icinga2_pki_dir}/ca.crt --cert #{icinga2_pki_dir}/host.example.org.crt",
             },
           ).that_notifies('Class[icinga2::service]')
         }


### PR DESCRIPTION


### Pull Request (PR) description
Update the PKI enrollment logic to retry certificate requests until the CA signing request is approved, ensuring the node certificate is replaced with a CA-signed certificate once accepted.
Also add a bit of documentation.

### This Pull Request (PR) fixes the following issues
Icinga::Feature::Api configured with pki 'icinga2' currently only generates self-signed certificates.  

After struggling a bit to get the internal CA working with puppet properly, i figured out something must be fixed.  
Unless i'm missing something, puppet generates a local cert that never gets updated.  
'pki request' command runs once, downloads the CA, never updates the cert.